### PR TITLE
[1.19] Simplified Persistent State Manager 

### DIFF
--- a/src/main/java/io/wispforest/owo/Owo.java
+++ b/src/main/java/io/wispforest/owo/Owo.java
@@ -4,6 +4,7 @@ import io.wispforest.owo.command.debug.OwoDebugCommands;
 import io.wispforest.owo.itemgroup.json.GroupTabLoader;
 import io.wispforest.owo.moddata.ModDataLoader;
 import io.wispforest.owo.ops.LootOps;
+import io.wispforest.owo.persistence.OwoPersistentStateManager;
 import io.wispforest.owo.text.InsertingTextContent;
 import net.fabricmc.api.ModInitializer;
 import net.fabricmc.fabric.api.event.lifecycle.v1.ServerLifecycleEvents;
@@ -50,6 +51,8 @@ public class Owo implements ModInitializer {
 
         ServerLifecycleEvents.SERVER_STARTING.register(server -> SERVER = server);
         ServerLifecycleEvents.SERVER_STOPPED.register(server -> SERVER = null);
+
+        OwoPersistentStateManager.init();
 
         if (!DEBUG) return;
 

--- a/src/main/java/io/wispforest/owo/persistence/OwoPersistentState.java
+++ b/src/main/java/io/wispforest/owo/persistence/OwoPersistentState.java
@@ -1,0 +1,18 @@
+package io.wispforest.owo.persistence;
+
+import net.minecraft.nbt.NbtCompound;
+import net.minecraft.world.PersistentState;
+
+/**
+ * A wrapper for PersistentState that simplifies the process of registration and usage. MUST
+ * @param <T> The class that is extending OwoPersistentState
+ */
+public abstract class OwoPersistentState<T> extends PersistentState {
+
+    /**
+     * The method that turns an NbtCompound into an instance of your class.
+     * @param compound The NbtCompound
+     * @return Instance of your class.
+     */
+    public abstract OwoPersistentState<T> gather(NbtCompound compound);
+}

--- a/src/main/java/io/wispforest/owo/persistence/OwoPersistentStateManager.java
+++ b/src/main/java/io/wispforest/owo/persistence/OwoPersistentStateManager.java
@@ -1,0 +1,60 @@
+package io.wispforest.owo.persistence;
+
+import net.fabricmc.fabric.api.event.lifecycle.v1.ServerWorldEvents;
+import net.minecraft.nbt.NbtCompound;
+import net.minecraft.server.MinecraftServer;
+import net.minecraft.server.world.ServerWorld;
+import net.minecraft.util.Identifier;
+import net.minecraft.util.Pair;
+import net.minecraft.world.PersistentStateManager;
+import net.minecraft.world.World;
+import org.jetbrains.annotations.ApiStatus;
+
+import javax.annotation.Nullable;
+import java.util.HashMap;
+import java.util.function.Function;
+import java.util.function.Supplier;
+
+public class OwoPersistentStateManager {
+
+    static HashMap<String, Pair<Function<NbtCompound, OwoPersistentState<?>>, Supplier<OwoPersistentState<?>>>> REGISTERED_STATES = new HashMap<>();
+
+    @ApiStatus.Internal
+    public static void init() {
+        ServerWorldEvents.LOAD.register((server, world) -> {
+            PersistentStateManager manager = world.getPersistentStateManager();
+            REGISTERED_STATES.forEach((identifier, functionSupplierPair) -> {
+                manager.getOrCreate(functionSupplierPair.getLeft(), functionSupplierPair.getRight(), identifier);
+            });
+        });
+    }
+
+    /**
+     * Get an instance of a persistent state from a world.
+     * @param world The world
+     * @param id The ID used to register the persistent state.
+     * @return The instance of the persistent state on the world.
+     * @param <T> The class of the persistent state.
+     */
+    public static <T extends OwoPersistentState<?>> T get(ServerWorld world, String id) {
+        Pair<Function<NbtCompound, OwoPersistentState<?>>, Supplier<OwoPersistentState<?>>> val = REGISTERED_STATES.get(id);
+        return (T) world.getPersistentStateManager().get(val.getLeft(), id);
+    }
+
+    /**
+     * Register your OwoPersistentState ready for world load.
+     * @param id The ID of your state - this will also be used as the .dat file name.
+     * @param owoPersistentState Default instance of your OwoPersistentState class
+     * @param <T> The type that extends OwoPersistentState
+     * @return False if failed to register (unlikely). True if successfully registered.
+     */
+    public static <T extends OwoPersistentState<?>> boolean register(String id, T owoPersistentState) {
+        try {
+            T defaultInstance = (T) owoPersistentState.getClass().newInstance();
+            REGISTERED_STATES.put(id, new Pair<>(defaultInstance::gather, () -> defaultInstance));
+            return true;
+        } catch (InstantiationException | IllegalAccessException e) {
+            return false;
+        }
+    }
+}

--- a/src/testmod/java/io/wispforest/uwu/persistence/UwuCounterState.java
+++ b/src/testmod/java/io/wispforest/uwu/persistence/UwuCounterState.java
@@ -1,0 +1,24 @@
+package io.wispforest.uwu.persistence;
+
+import io.wispforest.owo.persistence.OwoPersistentState;
+import net.minecraft.nbt.NbtCompound;
+
+public class UwuCounterState extends OwoPersistentState<UwuCounterState> {
+    public static final String ID = "uwu_state";
+
+    public int uwuws = 0;
+
+    @Override
+    public OwoPersistentState<UwuCounterState> gather(NbtCompound compound) {
+        UwuCounterState state = new UwuCounterState();
+
+        state.uwuws = compound.getInt("uwuCounts");
+        return state;
+    }
+
+    @Override
+    public NbtCompound writeNbt(NbtCompound nbt) {
+        nbt.putInt("uwuCounts", uwuws);
+        return nbt;
+    }
+}


### PR DESCRIPTION
The `OwoPersistentStateManager` will allow developers to swiftly create `PersistentStates` and get them from any point in server based code.

This is a simple alternative to Cardinal Components World which minimalizes the complexity.

### Practial Example:

![](https://oh.why-am-i-he.re/5C2k9VLui.png)

**Registration**

```java
OwoPersistentStateManager.register(UwuCounterState.ID, new UwuCounterState());
```

**Usage**

```java
UwuCounterState state = OwoPersistentStateManager.get(world, UwuCounterState.ID);

state.uwuws++;
state.markDirty(); // Will be saved on next server world save.

context.getSource().sendFeedback(Text.literal("UwUs incremented to: " + state.uwuws), false);
```

**`UwuCounterState` Class**

```java
public class UwuCounterState extends OwoPersistentState<UwuCounterState> {
    public static final String ID = "uwu_state";

    public int uwuws = 0;

    @Override
    public OwoPersistentState<UwuCounterState> gather(NbtCompound compound) {
        UwuCounterState state = new UwuCounterState();

        state.uwuws = compound.getInt("uwuCounts");
        return state;
    }

    @Override
    public NbtCompound writeNbt(NbtCompound nbt) {
        nbt.putInt("uwuCounts", uwuws);
        return nbt;
    }
}
```

**Saved Data in `<world>/data/uwu_state.dat`**

```dat
"": {
    data: {
        uwuCounts: 1
    }
    DataVersion: 3105
}
```


