### PR TITLE
Add API for inspecting planned tag injections

### DIFF
--- a/src/main/java/io/wispforest/owo/util/TagInjector.java
+++ b/src/main/java/io/wispforest/owo/util/TagInjector.java
@@ -20,23 +20,26 @@ public class TagInjector {
     @ApiStatus.Internal
     public static final HashMap<TagLocation, Set<TagEntry>> ADDITIONS = new HashMap<>();
 
+
+    private static final Map<TagLocation, Set<TagEntry>> ADDITIONS_VIEW = new ForwardingMap<>() {
+        @Override
+        protected @NotNull Map<TagLocation, Set<TagEntry>> delegate() {
+            return Collections.unmodifiableMap(ADDITIONS);
+        }
+
+        @Override
+        public Set<TagEntry> get(@Nullable Object key) {
+            return Collections.unmodifiableSet(delegate().get(key));
+        }
+    };
+
     /**
      * Retrieves an unmodifiable map of all planned tag injections.
      *
      * @return An immutable view of the planned tag injections.
      */
     public static Map<TagLocation, Set<TagEntry>> getInjections() {
-        return new ForwardingMap<>() {
-            @Override
-            protected @NotNull Map<TagLocation, Set<TagEntry>> delegate() {
-                return Collections.unmodifiableMap(ADDITIONS);
-            }
-
-            @Override
-            public Set<TagEntry> get(@Nullable Object key) {
-                return Collections.unmodifiableSet(delegate().get(key));
-            }
-        };
+        return ADDITIONS_VIEW;
     }
 
     /**

--- a/src/main/java/io/wispforest/owo/util/TagInjector.java
+++ b/src/main/java/io/wispforest/owo/util/TagInjector.java
@@ -1,10 +1,14 @@
 package io.wispforest.owo.util;
 
+import com.google.common.collect.ForwardingMap;
+import com.google.common.collect.ImmutableMap;
 import net.minecraft.tag.TagEntry;
 import net.minecraft.tag.TagManagerLoader;
 import net.minecraft.util.Identifier;
 import net.minecraft.util.registry.Registry;
 import org.jetbrains.annotations.ApiStatus;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
 import java.util.*;
 import java.util.function.Function;
@@ -16,6 +20,25 @@ public class TagInjector {
 
     @ApiStatus.Internal
     public static final HashMap<TagLocation, Set<TagEntry>> ADDITIONS = new HashMap<>();
+
+    /**
+     * Retrieves an unmodifiable map of all planned tag injections.
+     *
+     * @return An immutable view of the planned tag injections.
+     */
+    public static Map<TagLocation, Set<TagEntry>> getInjections() {
+        return Collections.unmodifiableMap(new ForwardingMap<>() {
+            @Override
+            protected @NotNull Map<TagLocation, Set<TagEntry>> delegate() {
+                return Collections.unmodifiableMap(ADDITIONS);
+            }
+
+            @Override
+            public Set<TagEntry> get(@Nullable Object key) {
+                return Collections.unmodifiableSet(delegate().get(key));
+            }
+        });
+    }
 
     /**
      * Injects the given Identifiers into the given Tag.

--- a/src/main/java/io/wispforest/owo/util/TagInjector.java
+++ b/src/main/java/io/wispforest/owo/util/TagInjector.java
@@ -26,7 +26,7 @@ public class TagInjector {
      * @return An immutable view of the planned tag injections.
      */
     public static Map<TagLocation, Set<TagEntry>> getInjections() {
-        return Collections.unmodifiableMap(new ForwardingMap<>() {
+        return new ForwardingMap<>() {
             @Override
             protected @NotNull Map<TagLocation, Set<TagEntry>> delegate() {
                 return Collections.unmodifiableMap(ADDITIONS);
@@ -36,7 +36,7 @@ public class TagInjector {
             public Set<TagEntry> get(@Nullable Object key) {
                 return Collections.unmodifiableSet(delegate().get(key));
             }
-        });
+        };
     }
 
     /**

--- a/src/main/java/io/wispforest/owo/util/TagInjector.java
+++ b/src/main/java/io/wispforest/owo/util/TagInjector.java
@@ -1,7 +1,6 @@
 package io.wispforest.owo.util;
 
 import com.google.common.collect.ForwardingMap;
-import com.google.common.collect.ImmutableMap;
 import net.minecraft.tag.TagEntry;
 import net.minecraft.tag.TagManagerLoader;
 import net.minecraft.util.Identifier;


### PR DESCRIPTION
For a mod of mine (Dynamic Asset Generator), I need to be able to inspect tags before tags are loaded, for various reasons. Generally, this can be done by just loading the data packs in question using a custom tool; however, as owo-lib injects tag entries directly into the tag loader, this does not work. I can build compatibility on my end if I have some way to look at planned tag injections before they are actually injected; this PR gives a way to do that.

Currently, the implementation uses unmodifiable maps and sets; however, there are other ways it could be implemented. Let me know if you'd like me to change stuff.