### PR TITLE
Make ItemComponent use the passed MatrixStack

### DIFF
--- a/src/main/java/io/wispforest/owo/mixin/ui/ItemRendererMixin.java
+++ b/src/main/java/io/wispforest/owo/mixin/ui/ItemRendererMixin.java
@@ -1,0 +1,50 @@
+package io.wispforest.owo.mixin.ui;
+
+import io.wispforest.owo.ui.util.ItemRendererExtension;
+import net.minecraft.client.font.TextRenderer;
+import net.minecraft.client.render.item.ItemRenderer;
+import net.minecraft.client.util.math.MatrixStack;
+import net.minecraft.item.ItemStack;
+import org.jetbrains.annotations.Nullable;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Shadow;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.ModifyVariable;
+
+@Mixin(ItemRenderer.class)
+public abstract class ItemRendererMixin implements ItemRendererExtension {
+
+    @Shadow public abstract void renderGuiItemOverlay(TextRenderer renderer, ItemStack stack, int x, int y, @Nullable String countLabel);
+
+    @Shadow public float zOffset;
+
+    @Nullable private MatrixStack cachedMatrixStack = null;
+
+    @ModifyVariable(method = "renderGuiItemOverlay(Lnet/minecraft/client/font/TextRenderer;Lnet/minecraft/item/ItemStack;IILjava/lang/String;)V", at = @At(value = "INVOKE", target = "Lnet/minecraft/client/util/math/MatrixStack;<init>()V", shift = At.Shift.BY, by = 2))
+    private MatrixStack owo$replaceMatrixStackIfCached(MatrixStack matrixStack){
+        return cachedMatrixStack != null ? cachedMatrixStack : matrixStack;
+    }
+
+    @Override
+    public void renderGuiItemOverlay(MatrixStack matrices, TextRenderer renderer, ItemStack stack, int x, int y, int z, @Nullable String countLabel) {
+        this.cachedMatrixStack = matrices;
+
+        float prevZOffset = this.zOffset;
+
+        // Used to offset the built-in static Z offset the MatrixStack will be given
+        this.zOffset = z - 200;
+
+        // Prevent bad things if they give us Null MatrixStack as error could be kinda hard to track down idk
+        if(this.cachedMatrixStack != null) this.cachedMatrixStack.push();
+
+        this.renderGuiItemOverlay(renderer, stack, x, y, countLabel);
+
+        this.zOffset = prevZOffset;
+
+        if(this.cachedMatrixStack != null) {
+            this.cachedMatrixStack.pop();
+
+            this.cachedMatrixStack = null;
+        }
+    }
+}

--- a/src/main/java/io/wispforest/owo/ui/component/ItemComponent.java
+++ b/src/main/java/io/wispforest/owo/ui/component/ItemComponent.java
@@ -1,11 +1,11 @@
 package io.wispforest.owo.ui.component;
 
-import com.mojang.blaze3d.systems.RenderSystem;
 import io.wispforest.owo.ui.base.BaseComponent;
 import io.wispforest.owo.ui.core.Sizing;
 import io.wispforest.owo.ui.parsing.UIModel;
 import io.wispforest.owo.ui.parsing.UIModelParsingException;
 import io.wispforest.owo.ui.parsing.UIParsing;
+import io.wispforest.owo.ui.util.ItemRendererExtension;
 import net.fabricmc.fabric.api.client.rendering.v1.TooltipComponentCallback;
 import net.minecraft.client.MinecraftClient;
 import net.minecraft.client.gui.tooltip.TooltipComponent;
@@ -55,35 +55,28 @@ public class ItemComponent extends BaseComponent {
     @Override
     public void draw(MatrixStack matrices, int mouseX, int mouseY, float partialTicks, float delta) {
         final boolean notSideLit = !this.itemRenderer.getModel(this.stack, null, null, 0).isSideLit();
-        if (notSideLit) {
-            DiffuseLighting.disableGuiDepthLighting();
-        }
+        if (notSideLit) DiffuseLighting.disableGuiDepthLighting();
 
-        var modelView = RenderSystem.getModelViewStack();
-        modelView.push();
+        matrices.push();
 
         // Translate to the root of the component
-        modelView.translate(x, y, 100);
+        matrices.translate(x, y, 0);
 
         // Scale according to component size and translate to the center
-        modelView.scale(this.width / 16f, this.height / 16f, 1);
-        modelView.translate(8.0, 8.0, 0.0);
+        matrices.scale(this.width / 16f, this.height / 16f, 1);
+        matrices.translate(8.0, 8.0, 0.0);
 
         // Vanilla scaling and y inversion
-        modelView.scale(16, -16, 16);
-        RenderSystem.applyModelViewMatrix();
+        matrices.scale(16, -16, 16);
 
         this.itemRenderer.renderItem(this.stack, ModelTransformation.Mode.GUI, LightmapTextureManager.MAX_LIGHT_COORDINATE, OverlayTexture.DEFAULT_UV, new MatrixStack(), entityBuffers, 0);
         this.entityBuffers.draw();
 
         // Clean up
-        modelView.pop();
-        RenderSystem.applyModelViewMatrix();
+        matrices.pop();
 
-        if (this.showOverlay) this.itemRenderer.renderGuiItemOverlay(MinecraftClient.getInstance().textRenderer, this.stack, this.x, this.y);
-        if (notSideLit) {
-            DiffuseLighting.enableGuiDepthLighting();
-        }
+        if (this.showOverlay) ((ItemRendererExtension) this.itemRenderer).renderGuiItemOverlay(matrices, MinecraftClient.getInstance().textRenderer, this.stack, 0, 0, 1);
+        if (notSideLit) DiffuseLighting.enableGuiDepthLighting();
     }
 
     public ItemComponent stack(ItemStack stack) {

--- a/src/main/java/io/wispforest/owo/ui/component/ItemComponent.java
+++ b/src/main/java/io/wispforest/owo/ui/component/ItemComponent.java
@@ -62,6 +62,8 @@ public class ItemComponent extends BaseComponent {
         // Translate to the root of the component
         matrices.translate(x, y, 0);
 
+        matrices.push();
+
         // Scale according to component size and translate to the center
         matrices.scale(this.width / 16f, this.height / 16f, 1);
         matrices.translate(8.0, 8.0, 0.0);
@@ -69,14 +71,17 @@ public class ItemComponent extends BaseComponent {
         // Vanilla scaling and y inversion
         matrices.scale(16, -16, 16);
 
-        this.itemRenderer.renderItem(this.stack, ModelTransformation.Mode.GUI, LightmapTextureManager.MAX_LIGHT_COORDINATE, OverlayTexture.DEFAULT_UV, new MatrixStack(), entityBuffers, 0);
+        this.itemRenderer.renderItem(this.stack, ModelTransformation.Mode.GUI, LightmapTextureManager.MAX_LIGHT_COORDINATE, OverlayTexture.DEFAULT_UV, matrices, entityBuffers, 0);
         this.entityBuffers.draw();
 
-        // Clean up
+        // Use base translations of components x, y
         matrices.pop();
 
         if (this.showOverlay) ((ItemRendererExtension) this.itemRenderer).renderGuiItemOverlay(matrices, MinecraftClient.getInstance().textRenderer, this.stack, 0, 0, 1);
         if (notSideLit) DiffuseLighting.enableGuiDepthLighting();
+
+        // Final Clean up
+        matrices.pop();
     }
 
     public ItemComponent stack(ItemStack stack) {

--- a/src/main/java/io/wispforest/owo/ui/util/ItemRendererExtension.java
+++ b/src/main/java/io/wispforest/owo/ui/util/ItemRendererExtension.java
@@ -1,0 +1,22 @@
+package io.wispforest.owo.ui.util;
+
+import net.minecraft.client.font.TextRenderer;
+import net.minecraft.client.util.math.MatrixStack;
+import net.minecraft.item.ItemStack;
+import org.jetbrains.annotations.Nullable;
+
+public interface ItemRendererExtension {
+
+    /**
+     * Helper method to pass a custom Matrices and Z Offset
+     */
+    default void renderGuiItemOverlay(MatrixStack matrices, TextRenderer renderer, ItemStack stack, int x, int y, int z) {
+        this.renderGuiItemOverlay(matrices, renderer, stack, x, y, z,null);
+    }
+
+    /**
+     * Helper method to pass a custom Matrices and Z Offset
+     */
+    void renderGuiItemOverlay(MatrixStack matrices, TextRenderer renderer, ItemStack stack, int x, int y, int z, @Nullable String countLabel);
+
+}

--- a/src/main/resources/owo.mixins.json
+++ b/src/main/resources/owo.mixins.json
@@ -63,6 +63,7 @@
     "ui.TextFieldWidgetAccessor",
     "ui.TextFieldWidgetMixin",
     "ui.TextRendererMixin",
+    "ui.ItemRendererMixin",
     "ui.layers.KeyboardMixin",
     "ui.layers.MouseMixin",
     "ui.layers.ScreenMixin",


### PR DESCRIPTION
The main purpose of this PR is for the ItemComponent to use its given MatrixStack rather than modifying the ModelViewStack.

Extra:
- Adds extension Util for better control on Rendering renderGuiItemOverlay with control on its position view a custom MatrixStack and Z-Offset value to select how far up from the MatrixStack you want