### PR TITLE
Tatar translations, more links for ModMenu Description and new translatable string ("Wiki").

### DIFF
--- a/src/main/resources/assets/owo/lang/en_us.json
+++ b/src/main/resources/assets/owo/lang/en_us.json
@@ -1,5 +1,4 @@
 {
-  "owo.wiki": "Wiki",
   "text.owo.itemGroup.tab_template": [
     { "index": 0 },
     { "text": " > ", "color": "gray" },

--- a/src/main/resources/assets/owo/lang/en_us.json
+++ b/src/main/resources/assets/owo/lang/en_us.json
@@ -1,4 +1,5 @@
 {
+  "owo.wiki": "Wiki",
   "text.owo.itemGroup.tab_template": [
     { "index": 0 },
     { "text": " > ", "color": "gray" },

--- a/src/main/resources/assets/owo/lang/tt_ru.json
+++ b/src/main/resources/assets/owo/lang/tt_ru.json
@@ -1,0 +1,79 @@
+{
+  "owo.wiki": "Вики",
+  "modmenu.descriptionTranslation.owo": "әйе бу начар мин беләм",
+  "modmenu.summaryTranslation.owo": "әйе бу начар мин беләм",
+  "text.owo.itemGroup.tab_template": [
+    { "index": 0 },
+    { "text": " > ", "color": "gray" },
+    { "index": 1, "color": "dark_gray" }
+  ],
+  "text.owo.config.search": "Эзләү...",
+  "text.owo.config.search.matches": "%$2d нәтиҗәдән %$1d нәтиҗә",
+  "text.owo.config.search.no_matches": "Нәтиҗәләр юк",
+  "text.owo.config.must_restart": "Сез керткән кайбер үзгәрешләр куллану өчен яңадан йөкләүне таләп итә",
+  "text.owo.config.button.exit_minecraft": "Minecraft-тан чыгу",
+  "text.owo.config.button.ignore_restart": "Яңадан кушу соңрак",
+  "text.owo.config.button.range.edit_as_text": "Текст сыман үзгәртү",
+  "text.owo.config.button.range.edit_with_slider": "Шудырма белән үзгәртү",
+  "text.owo.config.applies_after_restart": [
+    {
+      "text": "⏻ ",
+      "color": "#FAEA48"
+    },
+    {
+      "text": "Бу көйләү яңадан йөкләүдән соң кулланыла",
+      "color": "gray"
+    }
+  ],
+  "text.owo.config.managed_by_server": [
+    {
+      "text": "⚑ ",
+      "color": "#EB1D36"
+    },
+    {
+      "text": "Бу көйләү сервер белән идарә ителә\n   Үзгәртү өчен өзелегез",
+      "color": "gray"
+    }
+  ],
+  "text.owo.config.button.reload": "Яңадан йөкләү",
+  "text.owo.config.button.done": "Булды",
+  "text.owo.config.sections": [
+    {
+      "text": "Бүлекләр",
+      "underlined": true
+    }
+  ],
+  "text.owo.config.list.add_entry": "Элементны өстәү",
+  "text.owo.config.boolean_toggle.enabled": [
+    "",
+    {
+      "text": "[",
+      "color": "gray"
+    },
+    {
+      "text": "✔",
+      "color": "#28FFBF"
+    },
+    {
+      "text": "]",
+      "color": "gray"
+    },
+    " Кушык"
+  ],
+  "text.owo.config.boolean_toggle.disabled": [
+    "",
+    {
+      "text": "[",
+      "color": "gray"
+    },
+    {
+      "text": "❌",
+      "color": "#EB1D36"
+    },
+    {
+      "text": "]",
+      "color": "gray"
+    },
+    " Сүнек"
+  ]
+}

--- a/src/main/resources/assets/owo/lang/tt_ru.json
+++ b/src/main/resources/assets/owo/lang/tt_ru.json
@@ -1,5 +1,4 @@
 {
-  "owo.wiki": "Вики",
   "modmenu.descriptionTranslation.owo": "әйе бу начар мин беләм",
   "modmenu.summaryTranslation.owo": "әйе бу начар мин беләм",
   "text.owo.itemGroup.tab_template": [

--- a/src/main/resources/fabric.mod.json
+++ b/src/main/resources/fabric.mod.json
@@ -14,7 +14,6 @@
     "sources": "https://github.com/wisp-forest/owo-lib/",
     "issues": "https://github.com/wisp-forest/owo-lib/issues"
   },
-  },
   "license": "MIT",
   "icon": "assets/owo/icon.png",
   "environment": "*",

--- a/src/main/resources/fabric.mod.json
+++ b/src/main/resources/fabric.mod.json
@@ -10,7 +10,7 @@
     "Noaaan"
   ],
   "contact": {
-    "homepage": "https://docs.wispforest.io/owo/setup/",
+    "homepage": "https://modrinth.com/mod/owo-lib",
     "sources": "https://github.com/wisp-forest/owo-lib/",
     "issues": "https://github.com/wisp-forest/owo-lib/issues"
   },

--- a/src/main/resources/fabric.mod.json
+++ b/src/main/resources/fabric.mod.json
@@ -48,7 +48,7 @@
     "modmenu": {
       "links": {
         "modmenu.discord": "https://discord.gg/xrwHKktV2d",
-        "owo.wiki": "https://docs.wispforest.io/owo/features/"
+        "modmenu.wiki": "https://docs.wispforest.io/owo/features/"
       },
       "badges": [
         "library"

--- a/src/main/resources/fabric.mod.json
+++ b/src/main/resources/fabric.mod.json
@@ -9,7 +9,12 @@
     "BasiqueEvangelist",
     "Noaaan"
   ],
-  "contact": {},
+  "contact": {
+    "homepage": "https://docs.wispforest.io/owo/setup/",
+    "sources": "https://github.com/wisp-forest/owo-lib/",
+    "issues": "https://github.com/wisp-forest/owo-lib/issues"
+  },
+  },
   "license": "MIT",
   "icon": "assets/owo/icon.png",
   "environment": "*",
@@ -43,7 +48,8 @@
   "custom": {
     "modmenu": {
       "links": {
-        "modmenu.discord": "https://discord.gg/xrwHKktV2d"
+        "modmenu.discord": "https://discord.gg/xrwHKktV2d",
+        "owo.wiki": "https://docs.wispforest.io/owo/features/"
       },
       "badges": [
         "library"


### PR DESCRIPTION
Hello!

I made some changes, so there's explanation for them:
- Now there's more useful links (owo-lib's Wiki, Link to Issues and [link] to this Repository).
- Since I added link to Wiki page, I made "Wiki" button as translatable (en_us.json now has this string).
- Vanilla-ish Translation of this library into Tatar Language (all strings are translated in accordance with the Vanilla Minecraft translations + ModMenu Description translation + "Wiki" button translation).

![image](https://user-images.githubusercontent.com/51203385/221398496-570edbec-d234-4837-b1cc-e9da540b82cc.png)
_This is a how owo's ModMenu summary looks like now (All highlited elements are: Two buttons are Mod page (~~wiki~~ Modrinth page) and Mod Issues (github repository issues), translated into Tatar Lib description, two links (source and wiki pages))_