### PR TITLE
[owo-ui] Fixes the shadow on the component item

### DIFF
--- a/src/main/java/io/wispforest/owo/ui/component/ItemComponent.java
+++ b/src/main/java/io/wispforest/owo/ui/component/ItemComponent.java
@@ -21,6 +21,7 @@ import net.minecraft.item.ItemStack;
 import net.minecraft.registry.Registries;
 import net.minecraft.text.Text;
 import org.jetbrains.annotations.Nullable;
+import org.joml.Matrix4f;
 import org.w3c.dom.Element;
 
 import java.util.ArrayList;
@@ -68,7 +69,8 @@ public class ItemComponent extends BaseComponent {
         matrices.translate(8.0, 8.0, 0.0);
 
         // Vanilla scaling and y inversion
-        matrices.scale(16, -16, 16);
+        matrices.multiplyPositionMatrix((new Matrix4f()).scaling(1.0F, -1.0F, 1.0F));
+        matrices.scale(16, 16, 16);
 
         this.itemRenderer.renderItem(this.stack, ModelTransformationMode.GUI, LightmapTextureManager.MAX_LIGHT_COORDINATE, OverlayTexture.DEFAULT_UV, matrices, entityBuffers, null, 0);
         this.entityBuffers.draw();


### PR DESCRIPTION
Since the 1.19.4 version of owo-lib, the shadow of the item component is upside down

Current implementation:
![2023-03-28_23 55 08](https://user-images.githubusercontent.com/63565983/228416696-97645193-aaee-44f6-82b5-90ed19e42834.png)

This PR:
![2023-03-28_23 59 46](https://user-images.githubusercontent.com/63565983/228416708-07976ec4-19ca-42bb-b97f-4e4728870b54.png)

note: the top part of these items is cut off but that is because I just noticed that it is wrong in my mod