### PR TITLE
fix screen api workaround

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -5,13 +5,13 @@ org.gradle.jvmargs=-Xmx2G
 minecraft_base_version=1.19.4
 minecraft_version=1.19.4
 yarn_mappings=1.19.4+build.1
-loader_version=0.14.17
+loader_version=0.14.19
 # Mod Properties
 mod_version=0.10.4+pre.20
 maven_group=io.wispforest
 archives_base_name=owo-lib
 # Dependencies
-fabric_version=0.76.0+1.19.4
+fabric_version=0.81.1+1.19.4
 
 # https://maven.shedaniel.me/me/shedaniel/RoughlyEnoughItems-fabric/
 rei_version=11.0.597

--- a/src/main/java/io/wispforest/owo/ui/layers/Layers.java
+++ b/src/main/java/io/wispforest/owo/ui/layers/Layers.java
@@ -91,10 +91,7 @@ public final class Layers {
 
             ScreenEvents.afterRender(screeen).register((screen, matrices, mouseX, mouseY, tickDelta) -> {
                 for (var instance : getInstances(screen)) {
-                    matrices.push();
-                    matrices.translate(0, 0, 2000);
                     instance.adapter.render(matrices, mouseX, mouseY, tickDelta);
-                    matrices.pop();
                 }
             });
 


### PR DESCRIPTION
a bugfix in new fapi (FabricMC/Fabric#3061) makes the workaround in owo-ui layers make the layers not render.
removing the workaround fixes it