### PR TITLE
Fix armor trim rendering in ItemComponent (Fix #152)

### DIFF
--- a/src/main/java/io/wispforest/owo/ui/component/ItemComponent.java
+++ b/src/main/java/io/wispforest/owo/ui/component/ItemComponent.java
@@ -83,7 +83,7 @@ public class ItemComponent extends BaseComponent {
             matrices.multiplyPositionMatrix(ITEM_SCALING);
         }
 
-        MinecraftClient client = MinecraftClient.getInstance();
+        var client = MinecraftClient.getInstance();
 
         this.itemRenderer.renderItem(this.stack, ModelTransformationMode.GUI, LightmapTextureManager.MAX_LIGHT_COORDINATE, OverlayTexture.DEFAULT_UV, matrices, entityBuffers, client.world, 0);
         this.entityBuffers.draw();

--- a/src/main/java/io/wispforest/owo/ui/component/ItemComponent.java
+++ b/src/main/java/io/wispforest/owo/ui/component/ItemComponent.java
@@ -83,14 +83,16 @@ public class ItemComponent extends BaseComponent {
             matrices.multiplyPositionMatrix(ITEM_SCALING);
         }
 
-        this.itemRenderer.renderItem(this.stack, ModelTransformationMode.GUI, LightmapTextureManager.MAX_LIGHT_COORDINATE, OverlayTexture.DEFAULT_UV, matrices, entityBuffers, null, 0);
+        MinecraftClient client = MinecraftClient.getInstance();
+
+        this.itemRenderer.renderItem(this.stack, ModelTransformationMode.GUI, LightmapTextureManager.MAX_LIGHT_COORDINATE, OverlayTexture.DEFAULT_UV, matrices, entityBuffers, client.world, 0);
         this.entityBuffers.draw();
 
         // Clean up
         matrices.pop();
 
         if (this.showOverlay) {
-            context.drawItemInSlot(MinecraftClient.getInstance().textRenderer, this.stack, this.x, this.y);
+            context.drawItemInSlot(client.textRenderer, this.stack, this.x, this.y);
         }
         if (notSideLit) {
             DiffuseLighting.enableGuiDepthLighting();


### PR DESCRIPTION
This happened because the armor trims are dynamically stored in the world so it requires the dynamic registry of the current world

![image](https://github.com/wisp-forest/owo-lib/assets/63565983/5f1d272c-31e6-4720-94b9-46301ce66331)
