### PR TITLE
add text-transform property to text input related components

### DIFF
--- a/owo-ui.xsd
+++ b/owo-ui.xsd
@@ -176,6 +176,15 @@
         </xs:simpleContent>
     </xs:complexType>
 
+    <xs:simpleType name="owo-ui-text-transform">
+        <xs:restriction base="xs:string">
+            <xs:enumeration value="none"/>
+            <xs:enumeration value="lowercase"/>
+            <xs:enumeration value="uppercase"/>
+            <xs:enumeration value="capitalize"/>
+        </xs:restriction>
+    </xs:simpleType>
+
     <xs:simpleType name="owo-ui-color">
         <xs:annotation>
             <xs:documentation>
@@ -553,6 +562,7 @@
                     <xs:element type="xs:string" name="text" minOccurs="0"/>
                     <xs:element type="xs:unsignedInt" name="max-length" minOccurs="0"/>
                     <xs:element type="xs:boolean" name="show-background" minOccurs="0"/>
+                    <xs:element type="owo-ui-text-transform" name="transform" minOccurs="0"/>
                 </xs:choice>
             </xs:extension>
         </xs:complexContent>
@@ -567,6 +577,7 @@
                     <xs:element type="xs:unsignedInt" name="max-length" minOccurs="0"/>
                     <xs:element type="xs:unsignedInt" name="max-lines" minOccurs="0"/>
                     <xs:element type="xs:boolean" name="display-char-count" minOccurs="0"/>
+                    <xs:element type="owo-ui-text-transform" name="transform" minOccurs="0"/>
                 </xs:choice>
             </xs:extension>
         </xs:complexContent>

--- a/src/main/java/io/wispforest/owo/ui/component/TextAreaComponent.java
+++ b/src/main/java/io/wispforest/owo/ui/component/TextAreaComponent.java
@@ -6,6 +6,7 @@ import io.wispforest.owo.mixin.ui.access.EditBoxWidgetAccessor;
 import io.wispforest.owo.ui.core.CursorStyle;
 import io.wispforest.owo.ui.core.Size;
 import io.wispforest.owo.ui.core.Sizing;
+import io.wispforest.owo.ui.core.TextTransform;
 import io.wispforest.owo.ui.parsing.UIModel;
 import io.wispforest.owo.ui.parsing.UIParsing;
 import io.wispforest.owo.util.EventSource;
@@ -32,6 +33,7 @@ public class TextAreaComponent extends EditBoxWidget {
 
     protected final Observable<Boolean> displayCharCount = Observable.of(false);
     protected final Observable<Integer> maxLines = Observable.of(-1);
+    protected TextTransform transform = TextTransform.NONE;
 
     protected TextAreaComponent(Sizing horizontalSizing, Sizing verticalSizing) {
         super(MinecraftClient.getInstance().textRenderer, 0, 0, 0, 0, Text.empty(), Text.empty());
@@ -47,6 +49,8 @@ public class TextAreaComponent extends EditBoxWidget {
             if (this.maxLines.get() < 0) return;
             this.widgetWrapper().notifyParentIfMounted();
         });
+
+        this.onChanged().subscribe(this::checkTransform);
     }
 
     @Override
@@ -154,6 +158,23 @@ public class TextAreaComponent extends EditBoxWidget {
         return this;
     }
 
+    public TextTransform transform() {
+        return transform;
+    }
+
+    public TextAreaComponent transform(TextTransform transform) {
+        this.transform = transform;
+        checkTransform(getText());
+        return this;
+    }
+
+    protected void checkTransform(String value) {
+        String transformed = transform.apply(value);
+        if (!transformed.equals(value)) {
+            setText(transformed);
+        }
+    }
+
     @Override
     public int heightOffset() {
         return this.displayCharCount.get() ? -12 : 0;
@@ -167,6 +188,7 @@ public class TextAreaComponent extends EditBoxWidget {
         UIParsing.apply(children, "max-length", UIParsing::parseUnsignedInt, this::setMaxLength);
         UIParsing.apply(children, "max-lines", UIParsing::parseUnsignedInt, this::maxLines);
         UIParsing.apply(children, "text", $ -> $.getTextContent().strip(), this::text);
+        UIParsing.apply(children, "transform", TextTransform::parse, this::transform);
     }
 
     public interface OnChanged {

--- a/src/main/java/io/wispforest/owo/ui/core/TextTransform.java
+++ b/src/main/java/io/wispforest/owo/ui/core/TextTransform.java
@@ -1,0 +1,28 @@
+package io.wispforest.owo.ui.core;
+
+import org.apache.commons.lang3.text.WordUtils;
+import org.w3c.dom.Element;
+
+import java.util.Locale;
+import java.util.function.Function;
+
+public enum TextTransform {
+    NONE(str -> str),
+    LOWERCASE(String::toLowerCase),
+    UPPERCASE(String::toUpperCase),
+    CAPITALIZE(WordUtils::capitalizeFully);
+
+    private final Function<String, String> function;
+
+    TextTransform(Function<String, String> function) {
+        this.function = function;
+    }
+
+    public String apply(String src) {
+        return function.apply(src);
+    }
+
+    public static TextTransform parse(Element element) {
+        return valueOf(element.getTextContent().strip().toUpperCase(Locale.ROOT));
+    }
+}


### PR DESCRIPTION
text boxes and text areas now can have text-transform property, which allows simple text pre-processing:

`NONE`: `this UwU text` -> `this UwU text`
`LOWERCASE`: `this UwU text` -> `this uwu text`
`UPPERCASE`: `this UwU text` -> `THIS UWU TEXT`
`CAPITALIZE`: `this UwU text` -> `This Uwu Text`