### PR TITLE
AP Eclipse compatability

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -119,3 +119,7 @@ run/
 
 # generated sources
 /src/*/generated/
+bin/
+
+# Eclipse
+.settings/

--- a/gradle.properties
+++ b/gradle.properties
@@ -7,7 +7,7 @@ minecraft_version=1.20.2
 yarn_mappings=1.20.2+build.1
 loader_version=0.14.22
 # Mod Properties
-mod_version=0.11.3
+mod_version=0.11.4
 maven_group=io.wispforest
 archives_base_name=owo-lib
 # Dependencies

--- a/src/main/java/io/wispforest/owo/config/ConfigAP.java
+++ b/src/main/java/io/wispforest/owo/config/ConfigAP.java
@@ -123,7 +123,9 @@ public class ConfigAP extends AbstractProcessor {
                 var wrapperName = annotated.getAnnotation(Config.class).wrapperName();
 
                 try {
-                    var file = this.processingEnv.getFiler().createSourceFile(wrapperName);
+                    String packageName = getPackageName(className);
+                    String fqWrapperName = packageName + "." + wrapperName;
+                    var file = this.processingEnv.getFiler().createSourceFile(fqWrapperName);
                     try (var writer = new PrintWriter(file.openWriter())) {
                         writer.println(makeWrapper(wrapperName, className, this.collectFields(Option.Key.ROOT, clazz, clazz.getAnnotation(Config.class).defaultHook())));
                     }
@@ -355,5 +357,13 @@ public class ConfigAP extends AbstractProcessor {
         public @NotNull String toString() {
             return this.builder.toString();
         }
+    }
+
+    private String getPackageName(String fqn) {
+        int lastDotIndex = fqn.lastIndexOf('.');
+        if (lastDotIndex == -1) {
+            return "";
+        }
+        return fqn.substring(0, lastDotIndex);
     }
 }


### PR DESCRIPTION
Currently, the annotation processor is not compatabile with eclipse because eclipse will not recognize classes that do not exist in the proper filepath for their respective package.

This also ensures multiple configs with the same name would not collide in the event of multiple configs with the same name. 