### PR TITLE
Mouse enter event not being emitted on root component fix

### DIFF
--- a/src/main/java/io/wispforest/owo/ui/base/BaseComponent.java
+++ b/src/main/java/io/wispforest/owo/ui/base/BaseComponent.java
@@ -149,7 +149,7 @@ public abstract class BaseComponent implements Component {
         this.hovered = nowHovered;
 
         if (nowHovered) {
-            if (this.root() == null || this.root().childAt(mouseX, mouseY) != this) {
+            if (this.root() != null && this.root().childAt(mouseX, mouseY) != this) {
                 this.hovered = false;
                 return;
             }

--- a/src/main/java/io/wispforest/owo/ui/base/BaseParentComponent.java
+++ b/src/main/java/io/wispforest/owo/ui/base/BaseParentComponent.java
@@ -4,7 +4,6 @@ import io.wispforest.owo.ui.core.*;
 import io.wispforest.owo.ui.util.FocusHandler;
 import io.wispforest.owo.ui.util.ScissorStack;
 import io.wispforest.owo.util.Observable;
-import net.minecraft.client.util.math.MatrixStack;
 import net.minecraft.util.math.MathHelper;
 import org.jetbrains.annotations.Nullable;
 import org.lwjgl.glfw.GLFW;
@@ -51,6 +50,23 @@ public abstract class BaseParentComponent extends BaseComponent implements Paren
         }
     }
 
+    @Override
+    protected void updateHoveredState(int mouseX, int mouseY, boolean nowHovered) {
+        this.hovered = nowHovered;
+
+        if (nowHovered) {
+            ParentComponent root = this.root();
+            if ((root != null && root.childAt(mouseX, mouseY) != this) || (root == null && this.childAt(mouseX, mouseY) != null)) {
+                this.hovered = false;
+                return;
+            }
+
+            this.mouseEnterEvents.sink().onMouseEnter();
+        } else {
+            this.mouseLeaveEvents.sink().onMouseLeave();
+        }
+    }
+
     /**
      * Update the state of this component before drawing
      * the next frame. This method is separated from
@@ -61,7 +77,8 @@ public abstract class BaseParentComponent extends BaseComponent implements Paren
      * @param mouseX The mouse pointer's x-coordinate
      * @param mouseY The mouse pointer's y-coordinate
      */
-    protected void parentUpdate(float delta, int mouseX, int mouseY) {}
+    protected void parentUpdate(float delta, int mouseX, int mouseY) {
+    }
 
     @Override
     public void draw(OwoUIDrawContext context, int mouseX, int mouseY, float partialTicks, float delta) {

--- a/src/main/java/io/wispforest/owo/ui/base/BaseParentComponent.java
+++ b/src/main/java/io/wispforest/owo/ui/base/BaseParentComponent.java
@@ -56,7 +56,7 @@ public abstract class BaseParentComponent extends BaseComponent implements Paren
 
         if (nowHovered) {
             ParentComponent root = this.root();
-            if ((root != null && root.childAt(mouseX, mouseY) != this) || (root == null && this.childAt(mouseX, mouseY) != null)) {
+            if ((root != null && root.childAt(mouseX, mouseY) != this) || (root == null && this.childAt(mouseX, mouseY) != this)) {
                 this.hovered = false;
                 return;
             }


### PR DESCRIPTION
This fixes the mouse enter event not being emitted for root components or when using the Layer api. This is caused by the check to bypass the event if the component has no root component(ie current component is the root). The fix is just to only bypass the event if there is a root. However to keep the behavior of checking if a child should receive the event instead I also had to override updateHoveredState in BaseParentComponent to add the case that the current component might be the root and have children.