### PR TITLE
[1.21] Add Method extensions using Manifold Method Extensions

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -14,6 +14,11 @@ allprojects {
     version = "${project.mod_version}+${rootProject.minecraft_base_version}"
     group = rootProject.maven_group
 
+    repositories {
+        maven { url 'https://oss.sonatype.org/content/repositories/snapshots/' }
+        jcenter()
+    }
+
     dependencies {
         minecraft "com.mojang:minecraft:${rootProject.minecraft_version}"
         mappings "net.fabricmc:yarn:${rootProject.yarn_mappings}:v2"
@@ -41,6 +46,12 @@ allprojects {
         if (targetJavaVersion >= 10 || JavaVersion.current().isJava10Compatible()) {
             it.options.release = targetJavaVersion
         }
+
+        if (JavaVersion.current() != JavaVersion.VERSION_1_8 && sourceSets.main.allJava.files.any {it.name == "module-info.java"}) {
+            options.compilerArgs += ['-Xplugin:Manifold', '--module-path', it.classpath.asPath]
+        } else {
+            options.compilerArgs += ['-Xplugin:Manifold']
+        }
     }
 
     java {
@@ -58,6 +69,10 @@ allprojects {
     jar {
         from("LICENSE") {
             rename { "${it}_${project.archivesBaseName}" }
+        }
+
+        manifest {
+            attributes('Contains-Sources':'java,class')
         }
     }
 
@@ -138,6 +153,9 @@ dependencies {
 
     include api("blue.endless:jankson:${project.jankson_version}")
 
+    implementation testmodImplementation("systems.manifold:manifold-ext-rt:2024.1.17")
+    annotationProcessor testmodAnnotationProcessor("systems.manifold:manifold-ext:2024.1.17") // Add manifold to -processorpath for javac
+
     modCompileOnly("xyz.nucleoid:server-translations-api:${project.stapi_version}")
 
     testmodImplementation sourceSets.main.output
@@ -149,4 +167,10 @@ javadoc {
     options.tags = ["apiNote", "implNote", "implSpec"]
     options.addStringOption("Xdoclint:-missing", "-quiet")
     options.encoding = 'UTF-8'
+}
+
+jar {
+    manifest {
+        attributes('Contains-Sources':'java,class')
+    }
 }

--- a/build.gradle
+++ b/build.gradle
@@ -25,6 +25,9 @@ allprojects {
         modImplementation "net.fabricmc:fabric-loader:${rootProject.loader_version}"
 
         modImplementation "net.fabricmc.fabric-api:fabric-api:${project.fabric_version}"
+
+        implementation ("systems.manifold:manifold-ext-rt:${project.manifold_ext_version}")
+        annotationProcessor ("systems.manifold:manifold-ext:${project.manifold_ext_version}") // Add manifold to -processorpath for javac
     }
 
     processResources {
@@ -38,19 +41,15 @@ allprojects {
 
     def targetJavaVersion = 21
     tasks.withType(JavaCompile).configureEach {
-        // ensure that the encoding is set to UTF-8, no matter what the system default is
-        // this fixes some edge cases with special characters not displaying correctly
-        // see http://yodaconditions.net/blog/fix-for-java-file-encoding-problems-with-gradle.html
-        // If Javadoc is generated, this must be specified in that task too.
         it.options.encoding = "UTF-8"
         if (targetJavaVersion >= 10 || JavaVersion.current().isJava10Compatible()) {
             it.options.release = targetJavaVersion
         }
 
+        it.options.compilerArgs += ['-Xplugin:Manifold'];
+
         if (JavaVersion.current() != JavaVersion.VERSION_1_8 && sourceSets.main.allJava.files.any {it.name == "module-info.java"}) {
-            options.compilerArgs += ['-Xplugin:Manifold', '--module-path', it.classpath.asPath]
-        } else {
-            options.compilerArgs += ['-Xplugin:Manifold']
+            it.options.compilerArgs += ['--module-path', it.classpath.asPath]
         }
     }
 
@@ -153,13 +152,13 @@ dependencies {
 
     include api("blue.endless:jankson:${project.jankson_version}")
 
-    implementation testmodImplementation("systems.manifold:manifold-ext-rt:2024.1.17")
-    annotationProcessor testmodAnnotationProcessor("systems.manifold:manifold-ext:2024.1.17") // Add manifold to -processorpath for javac
-
     modCompileOnly("xyz.nucleoid:server-translations-api:${project.stapi_version}")
 
     testmodImplementation sourceSets.main.output
     testmodAnnotationProcessor sourceSets.main.output
+
+    testmodImplementation("systems.manifold:manifold-ext-rt:${project.manifold_ext_version}")
+    testmodAnnotationProcessor("systems.manifold:manifold-ext:${project.manifold_ext_version}") // Add manifold to -processorpath for javac
 }
 
 javadoc {

--- a/gradle.properties
+++ b/gradle.properties
@@ -27,3 +27,6 @@ modmenu_version=11.0.0-rc.2
 
 # https://maven.nucleoid.xyz/xyz/nucleoid/server-translations-api/
 stapi_version=2.3.1+1.21-pre2
+
+manifold_ext_version=2024.1.17
+

--- a/src/main/java/owolib/extensions/com/mojang/serialization/Codec/EndecExtensions.java
+++ b/src/main/java/owolib/extensions/com/mojang/serialization/Codec/EndecExtensions.java
@@ -1,11 +1,10 @@
 package owolib.extensions.com.mojang.serialization.Codec;
 
+import com.mojang.serialization.Codec;
 import io.wispforest.endec.Endec;
 import io.wispforest.owo.serialization.CodecUtils;
-import manifold.ext.rt.ForwardingExtensionMethod;
 import manifold.ext.rt.api.Extension;
 import manifold.ext.rt.api.This;
-import com.mojang.serialization.Codec;
 import org.jetbrains.annotations.ApiStatus;
 
 @ApiStatus.Internal

--- a/src/main/java/owolib/extensions/com/mojang/serialization/Codec/EndecExtensions.java
+++ b/src/main/java/owolib/extensions/com/mojang/serialization/Codec/EndecExtensions.java
@@ -1,0 +1,17 @@
+package owolib.extensions.com.mojang.serialization.Codec;
+
+import io.wispforest.endec.Endec;
+import io.wispforest.owo.serialization.CodecUtils;
+import manifold.ext.rt.ForwardingExtensionMethod;
+import manifold.ext.rt.api.Extension;
+import manifold.ext.rt.api.This;
+import com.mojang.serialization.Codec;
+import org.jetbrains.annotations.ApiStatus;
+
+@ApiStatus.Internal
+@Extension
+public final class EndecExtensions {
+    public static <A> Endec<A> toEndec(@This Codec<A> thiz) {
+        return CodecUtils.toEndec(thiz);
+    }
+}

--- a/src/main/java/owolib/extensions/io/wispforest/endec/Endec/CodecExtensions.java
+++ b/src/main/java/owolib/extensions/io/wispforest/endec/Endec/CodecExtensions.java
@@ -1,0 +1,45 @@
+package owolib.extensions.io.wispforest.endec.Endec;
+
+import com.mojang.datafixers.util.Either;
+import com.mojang.serialization.Codec;
+import io.wispforest.endec.Endec;
+import io.wispforest.endec.SerializationContext;
+import io.wispforest.owo.serialization.CodecUtils;
+import manifold.ext.rt.api.Extension;
+import manifold.ext.rt.api.This;
+import net.minecraft.network.PacketByteBuf;
+import net.minecraft.network.codec.PacketCodec;
+import org.jetbrains.annotations.ApiStatus;
+import org.jetbrains.annotations.NotNull;
+
+@ApiStatus.Internal
+@Extension
+public final class CodecExtensions {
+
+    @NotNull
+    public static <T> Codec<T> toCodec(@This Endec<T> thiz) {
+        return CodecUtils.toCodec(thiz);
+    }
+
+    @NotNull
+    public static <T> Codec<T> toCodec(@This Endec<T> thiz, SerializationContext assumedContext) {
+        return CodecUtils.toCodec(thiz, assumedContext);
+    }
+
+    @NotNull
+    public static <T, B extends PacketByteBuf> PacketCodec<B, T> toPacketCodec(@This Endec<T> endec) {
+        return CodecUtils.toPacketCodec(endec);
+    }
+
+    @NotNull
+    @Extension
+    public static <F, S> Endec<Either<F, S>> either(Endec<F> first, Endec<S> second) {
+        return CodecUtils.eitherEndec(first, second);
+    }
+
+    @NotNull
+    @Extension
+    public static <F, S> Endec<Either<F, S>> xor(Endec<F> first, Endec<S> second) {
+        return CodecUtils.xorEndec(first, second);
+    }
+}

--- a/src/main/java/owolib/extensions/io/wispforest/endec/StructEndec/StructEndecExtensions.java
+++ b/src/main/java/owolib/extensions/io/wispforest/endec/StructEndec/StructEndecExtensions.java
@@ -1,0 +1,21 @@
+package owolib.extensions.io.wispforest.endec.StructEndec;
+
+import com.mojang.serialization.MapCodec;
+import io.wispforest.endec.SerializationContext;
+import io.wispforest.owo.serialization.CodecUtils;
+import manifold.ext.rt.api.Extension;
+import manifold.ext.rt.api.This;
+import io.wispforest.endec.StructEndec;
+import org.jetbrains.annotations.ApiStatus;
+
+@ApiStatus.Internal
+@Extension
+public final class StructEndecExtensions {
+    public static <T> MapCodec<T> toMapCodec(@This StructEndec<T> thiz, SerializationContext assumedContext) {
+        return CodecUtils.toMapCodec(thiz, assumedContext);
+    }
+
+    public static <T> MapCodec<T> toMapCodec(@This StructEndec<T> thiz) {
+        return CodecUtils.toMapCodec(thiz);
+    }
+}


### PR DESCRIPTION
This PR adds some Method extensions for Codec, Endec, and StructEndec for easy time converting between various object types instead of touching the CodecUtil file. Such requires the use of the Manifold Plugin to see such within the various implemented classes.