### PR TITLE
Fix crash when the UI XML is invalid

### DIFF
--- a/src/main/java/io/wispforest/owo/ui/base/BaseOwoScreen.java
+++ b/src/main/java/io/wispforest/owo/ui/base/BaseOwoScreen.java
@@ -121,7 +121,9 @@ public abstract class BaseOwoScreen<R extends ParentComponent> extends Screen im
 
     @Override
     public boolean keyPressed(int keyCode, int scanCode, int modifiers) {
-        if ((modifiers & GLFW.GLFW_MOD_CONTROL) == 0 && this.uiAdapter != null
+        if (this.uiAdapter == null) return false;
+
+        if ((modifiers & GLFW.GLFW_MOD_CONTROL) == 0
                 && this.uiAdapter.rootComponent.focusHandler().focused() instanceof GreedyInputComponent inputComponent
                 && inputComponent.onKeyPress(keyCode, scanCode, modifiers)) {
             return true;

--- a/src/main/java/io/wispforest/owo/ui/base/BaseOwoScreen.java
+++ b/src/main/java/io/wispforest/owo/ui/base/BaseOwoScreen.java
@@ -121,7 +121,7 @@ public abstract class BaseOwoScreen<R extends ParentComponent> extends Screen im
 
     @Override
     public boolean keyPressed(int keyCode, int scanCode, int modifiers) {
-        if ((modifiers & GLFW.GLFW_MOD_CONTROL) == 0
+        if ((modifiers & GLFW.GLFW_MOD_CONTROL) == 0 && this.uiAdapter != null
                 && this.uiAdapter.rootComponent.focusHandler().focused() instanceof GreedyInputComponent inputComponent
                 && inputComponent.onKeyPress(keyCode, scanCode, modifiers)) {
             return true;
@@ -141,6 +141,8 @@ public abstract class BaseOwoScreen<R extends ParentComponent> extends Screen im
 
     @Override
     public boolean mouseDragged(double mouseX, double mouseY, int button, double deltaX, double deltaY) {
+        if (this.uiAdapter == null) return false;
+
         return this.uiAdapter.mouseDragged(mouseX, mouseY, button, deltaX, deltaY);
     }
 

--- a/src/testmod/java/io/wispforest/uwu/client/ParseFailScreen.java
+++ b/src/testmod/java/io/wispforest/uwu/client/ParseFailScreen.java
@@ -1,0 +1,17 @@
+package io.wispforest.uwu.client;
+
+import io.wispforest.owo.ui.base.BaseUIModelScreen;
+import io.wispforest.owo.ui.container.FlowLayout;
+import net.minecraft.util.Identifier;
+
+public class ParseFailScreen extends BaseUIModelScreen<FlowLayout> {
+
+    public ParseFailScreen() {
+        super(FlowLayout.class, DataSource.asset(Identifier.of("uwu", "parse_fail")));
+    }
+
+    @Override
+    protected void build(FlowLayout rootComponent) {
+
+    }
+}

--- a/src/testmod/java/io/wispforest/uwu/client/SelectUwuScreenScreen.java
+++ b/src/testmod/java/io/wispforest/uwu/client/SelectUwuScreenScreen.java
@@ -53,6 +53,7 @@ public class SelectUwuScreenScreen extends BaseOwoScreen<FlowLayout> {
         })));
         panel.child(Components.button(Text.literal("smolnite"), button -> this.client.setScreen(new SmolComponentTestScreen())));
         panel.child(Components.button(Text.literal("sizenite"), button -> this.client.setScreen(new SizingTestScreen())));
+        panel.child(Components.button(Text.literal("parse fail"), button -> this.client.setScreen(new ParseFailScreen())));
 
         this.uiAdapter.rootComponent.child(panel);
     }

--- a/src/testmod/resources/assets/uwu/owo_ui/parse_fail.xml
+++ b/src/testmod/resources/assets/uwu/owo_ui/parse_fail.xml
@@ -1,0 +1,23 @@
+<owo-ui xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:noNamespaceSchemaLocation="../../../../../../owo-ui.xsd">
+    <components>
+        <flow-layout direction="horizontal">
+            <children>
+                <button>
+                    <sizing>
+                        <horizontal method="fixed">100</horizontal>
+                        <vertical method="fixed">20</vertical>
+                    </sizing>
+                </button>
+            </children>
+
+            <horizontal-alignment>center</horizontal-alignment>
+            <vertical-alignment>center</vertical-alignment>
+
+            <surface>
+                <blur quality="3" size="5"/>
+            </surface>
+            <!-- invalid xml -->
+        </flow-layout
+    </components>
+</owo-ui>


### PR DESCRIPTION
This doesn't always happen, but sometimes when I'm working on a GUI, if I click again after the first error, it crashes:

* The `mouseDragged` one can be reproduced after several attempts of clicking and moving the mouse
* The `keyPressed` one is more complicated, but by commenting out `(modifiers & GLFW.GLFW_MOD_CONTROL) == 0 &&` and pressing keys right after clicking, I've managed to reproduce it



