### PR TITLE
Fix crash in developing when using ctrl+delete in a TextField

### DIFF
--- a/src/main/java/io/wispforest/owo/mixin/tweaks/TextFieldWidgetMixin.java
+++ b/src/main/java/io/wispforest/owo/mixin/tweaks/TextFieldWidgetMixin.java
@@ -32,7 +32,7 @@ public abstract class TextFieldWidgetMixin extends ClickableWidget {
             if (forward) {
                 cursorPosition++;
                 while (cursorPosition < this.text.length() && owo$isWordChar(this.text.charAt(cursorPosition))) cursorPosition++;
-            } else {
+            } else if (cursorPosition > 0) {
                 cursorPosition--;
                 while (cursorPosition > 0 && owo$isWordChar(this.text.charAt(cursorPosition - 1))) cursorPosition--;
             }


### PR DESCRIPTION
If you're developing with owo-lib, using a TextField, typing at least one character, moving to the beginning of the textfield, and pressing ctrl+delete will cause a crash. **This does not occur in production**