### PR TITLE
Fix infinite recursion in ops delegate loop

### DIFF
--- a/src/main/java/io/wispforest/owo/serialization/CodecUtils.java
+++ b/src/main/java/io/wispforest/owo/serialization/CodecUtils.java
@@ -201,7 +201,7 @@ public class CodecUtils {
                     });
 
                     var rootOps = ops;
-                    while (rootOps instanceof ForwardingDynamicOps<T1>) rootOps = ((ForwardingDynamicOpsAccessor<T1>) ops).owo$delegate();
+                    while (rootOps instanceof ForwardingDynamicOps<T1>) rootOps = ((ForwardingDynamicOpsAccessor<T1>) rootOps).owo$delegate();
 
                     var context = rootOps instanceof EdmOps edmOps
                             ? edmOps.capturedContext().and(assumedContext)
@@ -221,7 +221,7 @@ public class CodecUtils {
             public <T1> RecordBuilder<T1> encode(T input, DynamicOps<T1> ops, RecordBuilder<T1> prefix) {
                 try {
                     var rootOps = ops;
-                    while (rootOps instanceof ForwardingDynamicOps<T1>) rootOps = ((ForwardingDynamicOpsAccessor<T1>) ops).owo$delegate();
+                    while (rootOps instanceof ForwardingDynamicOps<T1>) rootOps = ((ForwardingDynamicOpsAccessor<T1>) rootOps).owo$delegate();
 
                     var context = rootOps instanceof EdmOps edmOps
                             ? edmOps.capturedContext().and(assumedContext)


### PR DESCRIPTION
Some of the delegate `while` loops in `CodecUtils` seem to be incorrectly using the variable `ops` instead of `rootOps`. This leads to infinite recursion and freezes the game when the delegate is nested.