### PR TITLE
[1.21] Codec conversion adjustments

### DIFF
--- a/src/main/java/io/wispforest/owo/mixin/CachedRegistryInfoGetterAccessor.java
+++ b/src/main/java/io/wispforest/owo/mixin/CachedRegistryInfoGetterAccessor.java
@@ -1,0 +1,11 @@
+package io.wispforest.owo.mixin;
+
+import net.minecraft.registry.RegistryOps;
+import net.minecraft.registry.RegistryWrapper;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.gen.Accessor;
+
+@Mixin(RegistryOps.CachedRegistryInfoGetter.class)
+public interface CachedRegistryInfoGetterAccessor {
+    @Accessor("registriesLookup") RegistryWrapper.WrapperLookup owo$getRegistriesLookup();
+}

--- a/src/main/java/io/wispforest/owo/serialization/CodecUtils.java
+++ b/src/main/java/io/wispforest/owo/serialization/CodecUtils.java
@@ -270,7 +270,7 @@ public class CodecUtils {
                 : assumedContext;
 
         if (ops instanceof RegistryOps<?> registryOps) {
-            context = context.withAttributes(RegistriesAttribute.infoGetterOnly(((RegistryOpsAccessor) registryOps).owo$infoGetter()));
+            context = context.withAttributes(RegistriesAttribute.tryFromCachedInfoGetter(((RegistryOpsAccessor) registryOps).owo$infoGetter()));
         }
 
         return context;

--- a/src/main/java/io/wispforest/owo/serialization/CodecUtils.java
+++ b/src/main/java/io/wispforest/owo/serialization/CodecUtils.java
@@ -189,7 +189,7 @@ public class CodecUtils {
         return toMapCodec(structEndec, SerializationContext.empty());
     }
 
-    public static <T> StructEndec<T> ofMapCodec(MapCodec<T> mapCodec) {
+    public static <T> StructEndec<T> toStructEndec(MapCodec<T> mapCodec) {
         return new StructEndec<T>() {
             @Override
             public void encodeStruct(SerializationContext ctx, Serializer<?> serializer, Serializer.Struct struct, T value) {

--- a/src/main/java/io/wispforest/owo/serialization/CodecUtils.java
+++ b/src/main/java/io/wispforest/owo/serialization/CodecUtils.java
@@ -261,7 +261,7 @@ public class CodecUtils {
 
     //--
 
-    private static SerializationContext createContext(DynamicOps<?> ops, SerializationContext assumedContext) {
+    public static SerializationContext createContext(DynamicOps<?> ops, SerializationContext assumedContext) {
         var rootOps = ops;
         while (rootOps instanceof ForwardingDynamicOps<?>) rootOps = ((ForwardingDynamicOpsAccessor<?>) rootOps).owo$delegate();
 
@@ -276,7 +276,7 @@ public class CodecUtils {
         return context;
     }
 
-    private static DynamicOps<EdmElement<?>> createEdmOps(SerializationContext ctx) {
+    public static DynamicOps<EdmElement<?>> createEdmOps(SerializationContext ctx) {
         DynamicOps<EdmElement<?>> ops = EdmOps.withContext(ctx);
 
         if (ctx.hasAttribute(RegistriesAttribute.REGISTRIES)) {

--- a/src/main/java/io/wispforest/owo/serialization/CodecUtils.java
+++ b/src/main/java/io/wispforest/owo/serialization/CodecUtils.java
@@ -13,12 +13,14 @@ import io.wispforest.owo.mixin.RegistryOpsAccessor;
 import io.wispforest.owo.serialization.endec.EitherEndec;
 import io.wispforest.owo.serialization.endec.MinecraftEndecs;
 import io.wispforest.owo.serialization.format.edm.EdmOps;
+import io.wispforest.owo.util.Scary;
 import net.fabricmc.fabric.api.networking.v1.PacketByteBufs;
 import net.minecraft.network.PacketByteBuf;
 import net.minecraft.network.RegistryByteBuf;
 import net.minecraft.network.codec.PacketCodec;
 import net.minecraft.registry.RegistryOps;
 import net.minecraft.util.dynamic.ForwardingDynamicOps;
+import org.jetbrains.annotations.ApiStatus;
 
 import java.util.HashMap;
 import java.util.Map;
@@ -189,6 +191,15 @@ public class CodecUtils {
         return toMapCodec(structEndec, SerializationContext.empty());
     }
 
+    /*
+     * This method overall should be fine but do not expect such tot work always as it could be a problem as
+     * it bypasses certain features about Deserializer API that may be an issue but is low chance for general
+     * cases within Minecraft.
+     *
+     * blodhgarm: 21.07.2024
+     */
+    @Scary
+    @ApiStatus.Experimental
     public static <T> StructEndec<T> toStructEndec(MapCodec<T> mapCodec) {
         return new StructEndec<T>() {
             @Override

--- a/src/main/java/io/wispforest/owo/serialization/CodecUtils.java
+++ b/src/main/java/io/wispforest/owo/serialization/CodecUtils.java
@@ -199,7 +199,7 @@ public class CodecUtils {
                         .getOrThrow(IllegalStateException::new)
                         .asMap();
 
-                if(serializer instanceof SelfDescribedDeserializer<?>) {
+                if(serializer instanceof SelfDescribedSerializer<?>) {
                     edmMap.value().forEach((s, element) -> struct.field(s, ctx, EdmEndec.INSTANCE, element));
                 } else {
                     struct.field("element", ctx, EdmEndec.MAP, edmMap);

--- a/src/main/java/io/wispforest/owo/serialization/RegistriesAttribute.java
+++ b/src/main/java/io/wispforest/owo/serialization/RegistriesAttribute.java
@@ -28,14 +28,24 @@ public final class RegistriesAttribute implements SerializationAttribute.Instanc
     }
 
     @ApiStatus.Internal
-    public static RegistriesAttribute infoGetterOnly(RegistryOps.RegistryInfoGetter lookup) {
+    public static RegistriesAttribute tryFromCachedInfoGetter(RegistryOps.RegistryInfoGetter lookup) {
+        return (lookup instanceof RegistryOps.CachedRegistryInfoGetter cachedGetter)
+                ? fromCachedInfoGetter(cachedGetter)
+                : fromInfoGetter(lookup);
+    }
+
+    public static RegistriesAttribute fromCachedInfoGetter(RegistryOps.CachedRegistryInfoGetter cachedGetter) {
         DynamicRegistryManager registryManager = null;
 
-        if(lookup instanceof RegistryOps.CachedRegistryInfoGetter getter && ((CachedRegistryInfoGetterAccessor) (Object) getter).owo$getRegistriesLookup() instanceof DynamicRegistryManager drm) {
+        if(((CachedRegistryInfoGetterAccessor) (Object) cachedGetter).owo$getRegistriesLookup() instanceof DynamicRegistryManager drm) {
             registryManager = drm;
         }
 
-        return new RegistriesAttribute(lookup, registryManager);
+        return new RegistriesAttribute(cachedGetter, registryManager);
+    }
+
+    public static RegistriesAttribute fromInfoGetter(RegistryOps.RegistryInfoGetter lookup) {
+        return new RegistriesAttribute(lookup, null);
     }
 
     public RegistryOps.RegistryInfoGetter infoGetter() {

--- a/src/main/java/io/wispforest/owo/serialization/RegistriesAttribute.java
+++ b/src/main/java/io/wispforest/owo/serialization/RegistriesAttribute.java
@@ -1,6 +1,7 @@
 package io.wispforest.owo.serialization;
 
 import io.wispforest.endec.SerializationAttribute;
+import io.wispforest.owo.mixin.CachedRegistryInfoGetterAccessor;
 import net.minecraft.registry.DynamicRegistryManager;
 import net.minecraft.registry.RegistryOps;
 import org.jetbrains.annotations.ApiStatus;
@@ -28,7 +29,13 @@ public final class RegistriesAttribute implements SerializationAttribute.Instanc
 
     @ApiStatus.Internal
     public static RegistriesAttribute infoGetterOnly(RegistryOps.RegistryInfoGetter lookup) {
-        return new RegistriesAttribute(lookup, null);
+        DynamicRegistryManager registryManager = null;
+
+        if(lookup instanceof RegistryOps.CachedRegistryInfoGetter getter && ((CachedRegistryInfoGetterAccessor) (Object) getter).owo$getRegistriesLookup() instanceof DynamicRegistryManager drm) {
+            registryManager = drm;
+        }
+
+        return new RegistriesAttribute(lookup, registryManager);
     }
 
     public RegistryOps.RegistryInfoGetter infoGetter() {

--- a/src/main/java/io/wispforest/owo/util/Scary.java
+++ b/src/main/java/io/wispforest/owo/util/Scary.java
@@ -1,0 +1,8 @@
+package io.wispforest.owo.util;
+
+/**
+ * Annotations used to indicate that a given whatever is design in some manor that may or may not
+ * cause you pain. Combined it might scare your skeleton out of your body having it run down the block.
+ */
+public @interface Scary {
+}

--- a/src/main/resources/owo.mixins.json
+++ b/src/main/resources/owo.mixins.json
@@ -39,7 +39,8 @@
     "ui.SimpleRegistryAccessor",
     "ui.SlotAccessor",
     "ui.SlotMixin",
-    "ui.access.BlockEntityAccessor"
+    "ui.access.BlockEntityAccessor",
+    "CachedRegistryInfoGetterAccessor"
   ],
   "client": [
     "ClientConfigurationNetworkHandlerMixin",


### PR DESCRIPTION
This PR adds a new `ofMapCodec` allowing the ability to convert a `MapCodec` to a `StructEndec` combined with code refactors to clean duplicate method calls within the class and adjust building `RegistriesAttribute` to attempt to get DRM from lookup. 

Thanks to @BasiqueEvangelist for discovering the very cursed work around for the conversion method

Supersedes #270 and #257 