### PR TITLE
[ui] Adjust the light direction in BlockComponent

### DIFF
--- a/src/main/java/io/wispforest/owo/ui/component/BlockComponent.java
+++ b/src/main/java/io/wispforest/owo/ui/component/BlockComponent.java
@@ -28,6 +28,7 @@ public class BlockComponent extends BaseComponent {
 
     private final BlockState state;
     private final @Nullable BlockEntity entity;
+    protected Vector3f light = new Vector3f(.6f, -.5f, 0.6f), light2 = new Vector3f(-.6f, -.5f, 0.5f);
 
     protected BlockComponent(BlockState state, @Nullable BlockEntity entity) {
         this.state = state;
@@ -48,7 +49,7 @@ public class BlockComponent extends BaseComponent {
         context.getMatrices().translate(-.5, -.5, -.5);
 
         RenderSystem.runAsFancy(() -> {
-            final var vertexConsumers = client.getBufferBuilders().getEntityVertexConsumers();
+            final var vertexConsumers = this.client.getBufferBuilders().getEntityVertexConsumers();
             if (this.state.getRenderType() != BlockRenderType.ENTITYBLOCK_ANIMATED) {
                 this.client.getBlockRenderManager().renderBlockAsEntity(
                         this.state, context.getMatrices(), vertexConsumers,
@@ -63,7 +64,7 @@ public class BlockComponent extends BaseComponent {
                 }
             }
 
-            RenderSystem.setShaderLights(new Vector3f(-1.5f, -.5f, 0), new Vector3f(0, -1, 0));
+            RenderSystem.setShaderLights(this.light, this.light2);
             vertexConsumers.draw();
             DiffuseLighting.enableGuiDepthLighting();
         });

--- a/src/testmod/java/io/wispforest/uwu/client/BlockTestScreen.java
+++ b/src/testmod/java/io/wispforest/uwu/client/BlockTestScreen.java
@@ -1,0 +1,148 @@
+package io.wispforest.uwu.client;
+
+import io.wispforest.owo.ui.base.BaseOwoScreen;
+import io.wispforest.owo.ui.component.BlockComponent;
+import io.wispforest.owo.ui.component.Components;
+import io.wispforest.owo.ui.component.DiscreteSliderComponent;
+import io.wispforest.owo.ui.container.Containers;
+import io.wispforest.owo.ui.container.FlowLayout;
+import io.wispforest.owo.ui.core.*;
+import net.minecraft.block.Block;
+import net.minecraft.block.BlockState;
+import net.minecraft.block.Blocks;
+import net.minecraft.block.entity.BlockEntity;
+import net.minecraft.registry.Registries;
+import net.minecraft.text.Text;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+import org.joml.Vector3f;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class BlockTestScreen extends BaseOwoScreen<FlowLayout> {
+    @Override
+    protected @NotNull OwoUIAdapter<FlowLayout> createAdapter() {
+        return OwoUIAdapter.create(this, Containers::verticalFlow);
+    }
+
+    @Override
+    protected void build(FlowLayout rootComponent) {
+        rootComponent.alignment(HorizontalAlignment.CENTER, VerticalAlignment.TOP);
+
+        var optionsLayout = Containers.horizontalFlow(Sizing.content(), Sizing.content());
+        var blocksLayout = Containers.ltrTextFlow(Sizing.fill(100), Sizing.content());
+
+        var airBlock = new TestBlockComponent(Blocks.AIR.getDefaultState(), null);
+        var light = airBlock.getLight();
+        var light2 = airBlock.getLight2();
+
+        var lightX = this.getSlider(light.x);
+        var lightY = this.getSlider(light.y);
+        var lightZ = this.getSlider(light.z);
+        var lightX2 = this.getSlider(light2.x);
+        var lightY2 = this.getSlider(light2.y);
+        var lightZ2 = this.getSlider(light2.z);
+        var allBlocks = Components.checkbox(Text.literal("All Blocks"));
+        var updateButton = Components.button(Text.of("Update blocks"), button -> {
+            float lightXValue = (float) lightX.discreteValue();
+            float lightYValue = (float) lightY.discreteValue();
+            float lightZValue = (float) lightZ.discreteValue();
+            float lightX2Value = (float) lightX2.discreteValue();
+            float lightY2Value = (float) lightY2.discreteValue();
+            float lightZ2Value = (float) lightZ2.discreteValue();
+            this.updateBlocks(blocksLayout, allBlocks.isChecked(), lightXValue, lightYValue, lightZValue, lightX2Value, lightY2Value, lightZ2Value);
+        });
+
+        var optionsGrid = Containers.grid(Sizing.content(), Sizing.content(), 2, 4);
+
+        optionsGrid.child(lightX, 0, 0);
+        optionsGrid.child(lightY, 0, 1);
+        optionsGrid.child(lightZ, 0, 2);
+        optionsGrid.child(lightX2, 1, 0);
+        optionsGrid.child(lightY2, 1, 1);
+        optionsGrid.child(lightZ2, 1, 2);
+
+        optionsGrid.child(updateButton, 0, 3);
+        optionsGrid.child(allBlocks, 1, 3);
+
+        optionsLayout.child(optionsGrid);
+
+        updateButton.onPress();
+
+        rootComponent.child(optionsLayout);
+        rootComponent.child(Containers.verticalScroll(Sizing.content(), Sizing.fill(), blocksLayout));
+    }
+
+    private DiscreteSliderComponent getSlider(float value) {
+        return Components.discreteSlider(Sizing.fixed(100), -3f, 3f)
+                .decimalPlaces(1)
+                .setFromDiscreteValue(value);
+    }
+
+    private void updateBlocks(FlowLayout layout, boolean allBlocks, float lightX, float lightY, float lightZ, float lightX2, float lightY2, float lightZ2) {
+        layout.clearChildren();
+
+        var testBlocks = this.getBlocks(allBlocks);
+        var blocksComponents = new ArrayList<Component>();
+
+        for (var block : testBlocks) {
+            var states = block.getStateManager().getStates();
+            for (var state : states) {
+                var blockComponent = new TestBlockComponent(state, null);
+                blockComponent.updateLights(new Vector3f(lightX, lightY, lightZ), new Vector3f(lightX2, lightY2, lightZ2));
+                blocksComponents.add(blockComponent.sizing(Sizing.fixed(25)).margins(Insets.of(3)));
+            }
+        }
+
+        layout.children(blocksComponents);
+    }
+
+    private List<Block> getBlocks(boolean allBlocks) {
+        if (allBlocks) {
+            return Registries.BLOCK.stream().toList();
+
+        }
+        return List.of(
+                Blocks.OAK_STAIRS,
+                Blocks.OAK_FENCE,
+                Blocks.LADDER,
+                Blocks.AMETHYST_CLUSTER,
+                Blocks.CAMPFIRE,
+                Blocks.POINTED_DRIPSTONE,
+                Blocks.PITCHER_CROP,
+                Blocks.OAK_SAPLING,
+                Blocks.CAVE_VINES,
+                Blocks.MANGROVE_PROPAGULE,
+                Blocks.CALIBRATED_SCULK_SENSOR,
+                Blocks.COPPER_DOOR,
+                Blocks.KELP_PLANT,
+                Blocks.POTTED_OAK_SAPLING,
+                Blocks.WATER_CAULDRON, //FIXME: water color is white
+                Blocks.RAIL,
+                Blocks.FIRE,
+                Blocks.COBWEB,
+                Blocks.SHORT_GRASS
+        );
+    }
+
+    private static class TestBlockComponent extends BlockComponent {
+
+        protected TestBlockComponent(BlockState state, @Nullable BlockEntity entity) {
+            super(state, entity);
+        }
+
+        private void updateLights(Vector3f light, Vector3f light2) {
+            this.light = light;
+            this.light2 = light2;
+        }
+
+        private Vector3f getLight() {
+            return this.light;
+        }
+
+        private Vector3f getLight2() {
+            return this.light2;
+        }
+    }
+}

--- a/src/testmod/java/io/wispforest/uwu/client/SelectUwuScreenScreen.java
+++ b/src/testmod/java/io/wispforest/uwu/client/SelectUwuScreenScreen.java
@@ -54,6 +54,7 @@ public class SelectUwuScreenScreen extends BaseOwoScreen<FlowLayout> {
         panel.child(Components.button(Text.literal("smolnite"), button -> this.client.setScreen(new SmolComponentTestScreen())));
         panel.child(Components.button(Text.literal("sizenite"), button -> this.client.setScreen(new SizingTestScreen())));
         panel.child(Components.button(Text.literal("parse fail"), button -> this.client.setScreen(new ParseFailScreen())));
+        panel.child(Components.button(Text.literal("blocks"), button -> this.client.setScreen(new BlockTestScreen())));
 
         this.uiAdapter.rootComponent.child(panel);
     }


### PR DESCRIPTION
### Description

Although the lighting now has less contrast on one side, it's also less saturated on the other, and there are blocks that don't appear strangely dark. I couldn't find values that achieve a similar contrast while preventing some blocks from appearing dark

If anyone can find values that match better with vanilla, I would appreciate it

### Comparison

<details>
<summary>Screenshots</summary>
Before

![before](https://github.com/user-attachments/assets/6ed2fd91-1e8b-46c8-923f-3dda3bbd30fb)

This PR

![pr](https://github.com/user-attachments/assets/a2d9d6e6-3324-486f-befa-3e89371c29fd)

Vanilla

![vanilla](https://github.com/user-attachments/assets/851046b9-1c17-4d2b-9d09-ba7ccf65c672)

</details>

<details>
<summary>Screenshots with zoom</summary>
Before

![before_zoom](https://github.com/user-attachments/assets/34101ebb-3985-4e1f-bf54-f816cda229cb)


This PR

![pr_zoom](https://github.com/user-attachments/assets/0cecd8dc-9a76-4421-b0bc-cb0ff758922c)


Vanilla

![vanilla_zoom](https://github.com/user-attachments/assets/463749ed-79f5-4b88-af6d-16053fcf034c)


</details>

Fix #157