### PR TITLE
Fix LabelComponent center alignment

### DIFF
--- a/src/main/java/io/wispforest/owo/ui/component/LabelComponent.java
+++ b/src/main/java/io/wispforest/owo/ui/component/LabelComponent.java
@@ -155,6 +155,7 @@ public class LabelComponent extends BaseComponent {
 
     @Override
     public void inflate(Size space) {
+        super.inflate(space);
         this.wrapLines();
         super.inflate(space);
     }


### PR DESCRIPTION
Bug description:
When trying to center a LabelComponent, the text is centered incorrectly

XML reproducer:
```xml
<owo-ui xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
    <components>
        <flow-layout direction="vertical" id="body">
            <children>
                <label>
                    <text>Groups</text>
                    <vertical-text-alignment>center</vertical-text-alignment>
                    <horizontal-text-alignment>center</horizontal-text-alignment>

                    <sizing>
                        <horizontal method="fill">20</horizontal>
                        <vertical method="fill">20</vertical>
                    </sizing>
                </label>
            </children>

            <surface>
                <flat>#C0101010</flat>
            </surface>
        </flow-layout>
    </components>
</owo-ui>
```

Actual behavior:
<img width="395" alt="image" src="https://github.com/user-attachments/assets/49e52b67-8850-48ad-8288-95a318bfac7c" />

Expected behavior:
<img width="400" alt="image" src="https://github.com/user-attachments/assets/cc455277-590d-46c0-b22a-e928299ae4f8" />

Fix note:
Double inflate fix this behaviour like in `TextAreaComponent`. Maybe its not optimal way to fix