### PR TITLE
fix showNametag not doing anything

### DIFF
--- a/src/main/java/io/wispforest/owo/mixin/ui/EntityRenderDispatcherMixin.java
+++ b/src/main/java/io/wispforest/owo/mixin/ui/EntityRenderDispatcherMixin.java
@@ -21,6 +21,9 @@ public class EntityRenderDispatcherMixin implements OwoEntityRenderDispatcherExt
     @Unique
     private boolean counterRotate = false;
 
+    @Unique
+    private boolean showNametag = false;
+
     @Override
     public void owo$setCounterRotate(boolean counterRotate) {
         this.counterRotate = counterRotate;
@@ -29,6 +32,16 @@ public class EntityRenderDispatcherMixin implements OwoEntityRenderDispatcherExt
     @Override
     public boolean owo$counterRotate() {
         return this.counterRotate;
+    }
+
+    @Override
+    public void owo$setShowNametag(boolean showNametag) {
+        this.showNametag = showNametag;
+    }
+
+    @Override
+    public boolean owo$showNametag() {
+        return showNametag;
     }
 
     @Shadow public Camera camera;

--- a/src/main/java/io/wispforest/owo/mixin/ui/EntityRendererMixin.java
+++ b/src/main/java/io/wispforest/owo/mixin/ui/EntityRendererMixin.java
@@ -15,6 +15,7 @@ import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Shadow;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.Redirect;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 
 @Mixin(EntityRenderer.class)
@@ -29,7 +30,13 @@ public class EntityRendererMixin<T extends Entity, S extends EntityRenderState> 
         if (!((OwoEntityRenderDispatcherExtension) this.dispatcher).owo$counterRotate()) return;
 
         matrices.multiply(new Quaternionf(this.dispatcher.getRotation()).invert());
-        matrices.multiply(RotationAxis.POSITIVE_Y.rotationDegrees(180));
+//        matrices.multiply(RotationAxis.POSITIVE_Y.rotationDegrees(180));
+    }
+
+    @Redirect(method = "updateRenderState", at = @At(value = "INVOKE", target = "Lnet/minecraft/client/render/entity/EntityRenderDispatcher;getSquaredDistanceToCamera(Lnet/minecraft/entity/Entity;)D"))
+    private double alwaysRenderNametag(EntityRenderDispatcher instance, Entity entity) {
+        if (!((OwoEntityRenderDispatcherExtension) this.dispatcher).owo$showNametag()) return this.dispatcher.getSquaredDistanceToCamera(entity);
+        return 0.0;
     }
 
 }

--- a/src/main/java/io/wispforest/owo/ui/component/EntityComponent.java
+++ b/src/main/java/io/wispforest/owo/ui/component/EntityComponent.java
@@ -124,7 +124,8 @@ public class EntityComponent<E extends Entity> extends BaseComponent {
             entityState,
             matrix,
             new ScreenRect(this.x, this.y, this.width, this.height),
-            context.scissorStack.peekLast()
+            context.scissorStack.peekLast(),
+            this.showNametag
         ));
     }
 

--- a/src/main/java/io/wispforest/owo/ui/component/EntityComponent.java
+++ b/src/main/java/io/wispforest/owo/ui/component/EntityComponent.java
@@ -118,14 +118,17 @@ public class EntityComponent<E extends Entity> extends BaseComponent {
         }
 
         var entityState = this.dispatcher.getRenderer(this.entity).createRenderState();
+
+        var dispatcher = (OwoEntityRenderDispatcherExtension) this.dispatcher;
+        dispatcher.owo$setShowNametag(this.showNametag);
         ((EntityRenderer)this.dispatcher.getRenderer(this.entity)).updateRenderState(this.entity, entityState, partialTicks);
+        dispatcher.owo$setShowNametag(false);
 
         context.state.addSpecialElement(new EntityElementRenderState(
             entityState,
             matrix,
             new ScreenRect(this.x, this.y, this.width, this.height),
-            context.scissorStack.peekLast(),
-            this.showNametag
+            context.scissorStack.peekLast()
         ));
     }
 

--- a/src/main/java/io/wispforest/owo/ui/renderstate/EntityElementRenderState.java
+++ b/src/main/java/io/wispforest/owo/ui/renderstate/EntityElementRenderState.java
@@ -17,8 +17,7 @@ public record EntityElementRenderState(
     EntityRenderState entityState,
     Matrix4f transform,
     ScreenRect bounds,
-    ScreenRect scissorArea,
-    boolean showNametag
+    ScreenRect scissorArea
 ) implements OwoSpecialElementRenderState<EntityElementRenderState> {
 
     @Override
@@ -80,7 +79,6 @@ public record EntityElementRenderState(
 
             var dispatcher = (OwoEntityRenderDispatcherExtension) this.dispatcher;
             dispatcher.owo$setCounterRotate(true);
-            dispatcher.owo$setShowNametag(state.showNametag);
 
             matrices.multiplyPositionMatrix(state.transform);
 
@@ -89,7 +87,6 @@ public record EntityElementRenderState(
             this.dispatcher.setRenderShadows(true);
 
             dispatcher.owo$setCounterRotate(false);
-            dispatcher.owo$setShowNametag(true);
         }
 
         @Override

--- a/src/main/java/io/wispforest/owo/ui/renderstate/EntityElementRenderState.java
+++ b/src/main/java/io/wispforest/owo/ui/renderstate/EntityElementRenderState.java
@@ -17,7 +17,8 @@ public record EntityElementRenderState(
     EntityRenderState entityState,
     Matrix4f transform,
     ScreenRect bounds,
-    ScreenRect scissorArea
+    ScreenRect scissorArea,
+    boolean showNametag
 ) implements OwoSpecialElementRenderState<EntityElementRenderState> {
 
     @Override
@@ -79,6 +80,7 @@ public record EntityElementRenderState(
 
             var dispatcher = (OwoEntityRenderDispatcherExtension) this.dispatcher;
             dispatcher.owo$setCounterRotate(true);
+            dispatcher.owo$setShowNametag(state.showNametag);
 
             matrices.multiplyPositionMatrix(state.transform);
 
@@ -87,6 +89,7 @@ public record EntityElementRenderState(
             this.dispatcher.setRenderShadows(true);
 
             dispatcher.owo$setCounterRotate(false);
+            dispatcher.owo$setShowNametag(true);
         }
 
         @Override

--- a/src/main/java/io/wispforest/owo/util/pond/OwoEntityRenderDispatcherExtension.java
+++ b/src/main/java/io/wispforest/owo/util/pond/OwoEntityRenderDispatcherExtension.java
@@ -3,4 +3,6 @@ package io.wispforest.owo.util.pond;
 public interface OwoEntityRenderDispatcherExtension {
     void owo$setCounterRotate(boolean counterRotation);
     boolean owo$counterRotate();
+    void owo$setShowNametag(boolean showNametag);
+    boolean owo$showNametag();
 }


### PR DESCRIPTION
Fixes the rendering of `showNametag`, previously it wouldn't render at all.

I'm not sure if there's a better solution than redirecting the `getSquaredDistanceToCamera` call, this seemed the easiest to me.
Comments out `matrices.multiply(RotationAxis.POSITIVE_Y.rotationDegrees(180));`, it seemed to do the opposite of whats expected but I may be missing something