### PR TITLE
Fix ConfigureHotReloadScreen in NeoForge environments

### DIFF
--- a/src/main/java/io/wispforest/owo/ui/parsing/ConfigureHotReloadScreen.java
+++ b/src/main/java/io/wispforest/owo/ui/parsing/ConfigureHotReloadScreen.java
@@ -35,7 +35,7 @@ public class ConfigureHotReloadScreen extends BaseUIModelScreen<FlowLayout> impl
 
     @Override
     protected void build(FlowLayout rootComponent) {
-        rootComponent.childById(LabelComponent.class, "ui-model-label").text(Text.translatable("text.owo.configure_hot_reload.model", this.modelId));
+        rootComponent.childById(LabelComponent.class, "ui-model-label").text(Text.translatable("text.owo.configure_hot_reload.model", this.modelId.toString()));
         this.fileNameLabel = rootComponent.childById(LabelComponent.class, "file-name-label");
         this.updateFileNameLabel();
 


### PR DESCRIPTION
Reported from Discord by sxtkl123.

NeoForge in contrast to Fabric environments has extra validation for what you are allowed to pass as an argument for translatable text (`Component.translatable()`). Because of this a `toString()` call is needed for the ConfigureHotReloadScreen to work correctly.

Introduced in this PR: https://github.com/neoforged/NeoForge/pull/924

Relevant patch:
~~https://github.com/neoforged/NeoForge/blob/backport/1.21.1/2706/patches/net/minecraft/network/chat/contents/TranslatableContents.java.patch~~

https://github.com/neoforged/NeoForge/blob/037d84584585fe7d5fc545325b92c5a16c57d3cc/patches/net/minecraft/network/chat/contents/TranslatableContents.java.patch