### PR TITLE
Fix SmallCheckboxComponent not toggling upon a left click

### DIFF
--- a/src/main/java/io/wispforest/owo/ui/component/SmallCheckboxComponent.java
+++ b/src/main/java/io/wispforest/owo/ui/component/SmallCheckboxComponent.java
@@ -72,7 +72,7 @@ public class SmallCheckboxComponent extends BaseComponent {
     public boolean onMouseDown(Click click, boolean doubled) {
         boolean result = super.onMouseDown(click, doubled);
 
-        if (click.isLeft()) {
+        if (click.button() == 0) {
             this.toggle();
             return true;
         }


### PR DESCRIPTION
This pull request fixes a bug that causes the small checkbox component to not toggle when you click on it. Upon clicking the checkbox, the code checks if you left clicked with ```click.isLeft()```. Since Click extends AbstractInput, ```AbstractInput.isLeft()``` checks if ```this.getKeycode() == 263```. Clicks implementation of ```getKeycode()``` returns ```this.button()```, which will be 0 if the user left-clicked, NOT 263. To fix this, I simply check if ```click.button() == 0```.