### PR TITLE
Fix compatibility with Fabric API 1.21.11

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -62,7 +62,7 @@ allprojects {
 
     jar {
         from("LICENSE") {
-            rename { "${it}_${project.archivesBaseName}" }
+            rename { "${it}_${project.base.archivesName.get()}" }
         }
     }
 

--- a/src/main/java/io/wispforest/owo/ext/DerivedComponentMap.java
+++ b/src/main/java/io/wispforest/owo/ext/DerivedComponentMap.java
@@ -32,8 +32,10 @@ public class DerivedComponentMap implements ComponentMap {
     public void derive(ItemStack owner) {
         delegate.setChanges(ComponentChanges.EMPTY);
         var builder = ComponentChanges.builder();
-        owner.getItem().deriveStackComponents(owner.getComponents(), builder);
-        delegate.setChanges(builder.build());
+        if (owner.getItem() instanceof OwoItem owoItem) {
+            owoItem.deriveStackComponents(owner.getComponents(), builder);
+        }
+        delegate.applyChanges(builder.build());
     }
 
     @Nullable
@@ -53,8 +55,8 @@ public class DerivedComponentMap implements ComponentMap {
             return true;
         } else if (o instanceof DerivedComponentMap thatDerived) {
             return Objects.equals(base, thatDerived.base);
-        } else if (o instanceof ComponentMap.Builder.SimpleComponentMap simpleComponentMap) {
-            return Objects.equals(base, simpleComponentMap);
+        } else if (o instanceof ComponentMap otherMap) {
+            return Objects.equals(base, otherMap);
         }
 
         return o == EMPTY && this.base == EMPTY;

--- a/src/main/java/io/wispforest/owo/mixin/ext/MergedComponentMapMixin.java
+++ b/src/main/java/io/wispforest/owo/mixin/ext/MergedComponentMapMixin.java
@@ -1,25 +1,51 @@
 package io.wispforest.owo.mixin.ext;
 
 import com.llamalad7.mixinextras.injector.ModifyExpressionValue;
-import com.llamalad7.mixinextras.injector.wrapoperation.Operation;
-import com.llamalad7.mixinextras.injector.wrapoperation.WrapOperation;
 import io.wispforest.owo.ext.DerivedComponentMap;
+import net.minecraft.component.ComponentChanges;
 import net.minecraft.component.ComponentMap;
 import net.minecraft.component.MergedComponentMap;
 import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Shadow;
 import org.spongepowered.asm.mixin.injection.At;
 
+import java.util.Objects;
+
 @Mixin(MergedComponentMap.class)
-public class MergedComponentMapMixin {
+public abstract class MergedComponentMapMixin {
+
+    @Shadow
+    private ComponentMap baseComponents;
+
+    @Shadow
+    public abstract ComponentChanges getChanges();
+
     @ModifyExpressionValue(method = "copy", at = @At(value = "FIELD", target = "Lnet/minecraft/component/MergedComponentMap;baseComponents:Lnet/minecraft/component/ComponentMap;"))
     private ComponentMap reWrapDerived(ComponentMap original) {
         return DerivedComponentMap.reWrapIfNeeded(original);
     }
 
-    @WrapOperation(method = "equals", at = @At(value = "INVOKE", target = "Lnet/minecraft/component/ComponentMap;equals(Ljava/lang/Object;)Z"))
-    private boolean prioritiseDerivedMap(ComponentMap instance, Object object, Operation<Boolean> original) {
-        return (object instanceof DerivedComponentMap derivedComponentMap)
-            ? original.call(derivedComponentMap, instance)
-            : original.call(instance, object);
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (!(o instanceof MergedComponentMap other)) return false;
+
+        ComponentMap otherBase = ((MergedComponentMapAccessor)(Object) other).owo$getBaseComponents();
+        ComponentChanges otherChanges = other.getChanges();
+
+        if (this.baseComponents instanceof DerivedComponentMap derivedBase) {
+            if (!derivedBase.equals(otherBase)) return false;
+        } else if (otherBase instanceof DerivedComponentMap derivedOther) {
+            if (!derivedOther.equals(this.baseComponents)) return false;
+        } else {
+            if (!Objects.equals(this.baseComponents, otherBase)) return false;
+        }
+
+        return Objects.equals(this.getChanges(), otherChanges);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(baseComponents, getChanges());
     }
 }

--- a/src/main/java/io/wispforest/owo/mixin/itemgroup/MixinCreativeInventoryScreenMixin.java
+++ b/src/main/java/io/wispforest/owo/mixin/itemgroup/MixinCreativeInventoryScreenMixin.java
@@ -2,71 +2,45 @@ package io.wispforest.owo.mixin.itemgroup;
 
 import it.unimi.dsi.fastutil.ints.Int2ObjectMap;
 import it.unimi.dsi.fastutil.ints.Int2ObjectOpenHashMap;
+import net.fabricmc.fabric.api.client.itemgroup.v1.FabricCreativeInventoryScreen;
 import net.minecraft.client.gui.screen.ingame.CreativeInventoryScreen;
 import net.minecraft.item.ItemGroup;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Shadow;
+import org.spongepowered.asm.mixin.Unique;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
-import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
 
-@SuppressWarnings({"MixinAnnotationTarget", "UnresolvedMixinReference"})
 @Mixin(value = CreativeInventoryScreen.class, priority = 1100)
 public abstract class MixinCreativeInventoryScreenMixin {
 
     @Shadow
     private static ItemGroup selectedTab;
 
-    @Shadow(remap = false) // FAPI
-    private static int currentPage;
-
+    @Unique
     private static final Int2ObjectMap<ItemGroup> owo$selectedTabForPage = new Int2ObjectOpenHashMap<>();
-    private static boolean owo$calledFromInit = false;
-
-    @Shadow(remap = false) // FAPI
-    private boolean isGroupVisible(ItemGroup itemGroup) { throw new RuntimeException(); }
-
-    @Shadow(remap = false) // FAPI
-    private void updateSelection() {}
 
     @Shadow
     protected abstract void setSelectedTab(ItemGroup group);
 
+    @Unique
+    private FabricCreativeInventoryScreen owo$self() {
+        return (FabricCreativeInventoryScreen) (Object) this;
+    }
+
     @Inject(method = "setSelectedTab", at = @At("TAIL"))
     private void captureSetTab(ItemGroup group, CallbackInfo ci) {
-        owo$selectedTabForPage.put(currentPage, group);
-    }
-
-    @Inject(method = "updateSelection", at = @At("HEAD"), cancellable = true, remap = false)
-    private void yesThisMakesPerfectSenseAndIsVeryUsable(CallbackInfo ci) {
-        if (owo$selectedTabForPage.get(currentPage) != null) {
-            this.setSelectedTab(owo$selectedTabForPage.get(currentPage));
-            ci.cancel();
-            return;
-        }
-
-        if (this.isGroupVisible(selectedTab)) {
-            ci.cancel();
-        }
-    }
-
-    @Inject(method = "init", at = @At("HEAD"))
-    private void prepareTheFixForTheFix(CallbackInfo ci) {
-        owo$calledFromInit = true;
-    }
-
-    @Inject(method = "getCurrentPage", at = @At("HEAD"), cancellable = true)
-    private void iLoveFixingTheFix(CallbackInfoReturnable<Integer> cir) {
-        if (!owo$calledFromInit) return;
-
-        cir.setReturnValue(currentPage);
-        owo$calledFromInit = false;
+        owo$selectedTabForPage.put(owo$self().getCurrentPage(), group);
     }
 
     @Inject(method = "init", at = @At("TAIL"))
-    private void endTheFixForTheFix(CallbackInfo ci) {
-        this.updateSelection();
-        owo$calledFromInit = false;
+    private void restoreTabSelection(CallbackInfo ci) {
+        int currentPage = owo$self().getCurrentPage();
+        ItemGroup savedTab = owo$selectedTabForPage.get(currentPage);
+
+        if (savedTab != null && owo$self().getPage(savedTab) == currentPage) {
+            this.setSelectedTab(savedTab);
+        }
     }
 }


### PR DESCRIPTION
- Update MixinCreativeInventoryScreenMixin to use FabricCreativeInventoryScreen interface
- Remove deprecated Shadow references to FAPI @Unique methods
- Fix DerivedComponentMap and MergedComponentMapMixin for 1.21.11 API changes