### PR TITLE
Fix NoClassDefFoundError in ConfigAP

### DIFF
--- a/src/main/java/io/wispforest/owo/config/ConfigAP.java
+++ b/src/main/java/io/wispforest/owo/config/ConfigAP.java
@@ -266,7 +266,7 @@ public class ConfigAP extends AbstractProcessor {
         @Override
         public void appendAccessors(Writer accessors, Writer optionInstances, Writer keyConstants) {
             var nestClassName = capitalize(nestName);
-            if (nestClassName.equals(typeName)) nestClassName += "_";
+            if (nestClassName.equalsIgnoreCase(typeName)) nestClassName += "_";
 
             accessors.beginLine("public final ").write(nestClassName).write(" ").write(nestName).write(" = new ").write(nestClassName).endLine("();");
             accessors.beginLine("public class ").write(nestClassName).write(" implements ").write(typeName).endLine(" {");


### PR DESCRIPTION
In certain cases when built on case insensitive filesystems, the generated config will throw a NoClassDefFoundError.
Currently nested classes are being checked for naming conflicts but not casing conflicts. For example a nested config section ```HUD hud = new HUD();``` results in an inner interface named ```HUD``` and inner class named ```Hud```, which aren't equal so no _ is appended. During compilation these files overwrite eachother leading to a NoClassDefFoundError.
Switching to equalsIgnoreCase catches both naming and casing conflicts.