### PR TITLE
(26.1) Add constructor to BaseOwoContainerScreen with image height and width

### DIFF
--- a/src/main/java/io/wispforest/owo/ui/base/BaseOwoContainerScreen.java
+++ b/src/main/java/io/wispforest/owo/ui/base/BaseOwoContainerScreen.java
@@ -44,6 +44,11 @@ public abstract class BaseOwoContainerScreen<R extends ParentUIComponent, S exte
      */
     protected boolean invalid = false;
 
+
+    protected BaseOwoContainerScreen(S menu, Inventory inventory, Component title, int imageWidth, int imageHeight) {
+        super(menu, inventory, title, imageWidth, imageHeight);
+    }
+
     protected BaseOwoContainerScreen(S menu, Inventory inventory, Component title) {
         super(menu, inventory, title);
     }


### PR DESCRIPTION
Required for Alloy Forgery, since these values are now `final` in vanilla