### PR TITLE
Fix hot reload configuration screen

### DIFF
--- a/src/main/java/io/wispforest/owo/ui/base/BaseUIModelScreen.java
+++ b/src/main/java/io/wispforest/owo/ui/base/BaseUIModelScreen.java
@@ -132,6 +132,20 @@ public abstract class BaseUIModelScreen<R extends ParentUIComponent> extends Bas
             return new AssetDataSource(assetPath);
         }
 
+        static DataSource preloaded(Identifier assetPath) {
+            return new DataSource() {
+                @Override
+                public @Nullable UIModel get() {
+                    return UIModelLoader.getPreloaded(assetPath);
+                }
+
+                @Override
+                public void reportError() {
+                    UIErrorToast.report("No UI model with id " + assetPath + " was found");
+                }
+            };
+        }
+
         record AssetDataSource(Identifier assetPath) implements DataSource {
             @Override
             public @Nullable UIModel get() {

--- a/src/main/java/io/wispforest/owo/ui/parsing/ConfigureHotReloadScreen.java
+++ b/src/main/java/io/wispforest/owo/ui/parsing/ConfigureHotReloadScreen.java
@@ -27,7 +27,7 @@ public class ConfigureHotReloadScreen extends BaseUIModelScreen<FlowLayout> impl
     private LabelComponent fileNameLabel;
 
     public ConfigureHotReloadScreen(Identifier modelId, @Nullable Screen parent) {
-        super(FlowLayout.class, DataSource.asset(Owo.id("configure_hot_reload")));
+        super(FlowLayout.class, DataSource.preloaded(Owo.id("configure_hot_reload")));
         this.parent = parent;
 
         this.modelId = modelId;


### PR DESCRIPTION
>Note: this description was written by me and grammar-overhauled by Claude.

Fixes #496

**TL;DR**

TLDR: I bricked `/owo-ui-set-reload-path` by misunderstanding its argument - instead of setting a reload path for my own screen (`/owo-ui-set-reload-path my-project:my_screen`), I set one for owo's own `owo:configure_hot_reload` screen. Once that happens, every subsequent `/owo-ui-set-reload-path` call crashes with a `NullPointerException` at `ConfigureHotReloadScreen.java:39`, and the only recovery I found was manually editing or deleting `run/config/owo_ui_hot_reload_locations.json5`. Fixed by having `ConfigureHotReloadScreen` load its model via `UIModelLoader.getPreloaded(...)` instead of `UIModelLoader.get(...)`, so it always uses its own bundled model regardless of what's in the (possibly broken) config file.

**Extended version**

`ConfigureHotReloadScreen` previously loaded its UI model via `UIModelLoader.get(...)`, which resolves the model according to whatever reload path is currently configured for that model's id - including the screen's own id, `owo:configure_hot_reload`. This means the screen was not exempt from its own reload-path mechanism: if a user (deliberately or, as in my case, accidentally) ran `/owo-ui-set-reload-path owo:configure_hot_reload` and pointed it at a file that isn't a valid replacement for the actual configure-hot-reload model, the screen would try to build itself from that mismatched/invalid model on every subsequent open. Since the resulting component tree doesn't contain the ids the Java code expects (e.g. the label looked up at line 39), `childById(...)` returns `null` and the following `.text(...)` call throws an NPE.

Because `/owo-ui-set-reload-path` itself opens `ConfigureHotReloadScreen` to pick the new path, once the config screen was bricked this way, there was no way to run the command again to fix it - every invocation crashed immediately. The only recovery was manually editing or deleting `run/config/owo_ui_hot_reload_locations.json5` outside the game.

This PR changes `ConfigureHotReloadScreen` to load its model via `UIModelLoader.getPreloaded(...)` instead of `UIModelLoader.get(...)`. This makes it always use its own bundled, known-good UI model rather than going through the reload-path resolution it itself manages, so it can no longer be pointed at an incompatible file for itself. As a result, the screen now also recovers gracefully even if `owo_ui_hot_reload_locations.json5` is already in a broken state from before this fix - no manual file editing is required.

The only downside is that a custom `owo:configure_hot_reload` model is no longer possible, since the screen now always uses its bundled model rather than an overridable one. I'd argue this is an acceptable trade-off, given that it's an internal debug/config tool rather than something mods or users are expected to reasonably want to reskin.